### PR TITLE
Fix test type

### DIFF
--- a/tests/generic/member/class_member_test_5.sv
+++ b/tests/generic/member/class_member_test_5.sv
@@ -12,6 +12,7 @@
 :description: Test
 :should_fail_because: pure virtual methods can only be declared in virtual classes
 :tags: 8.3
+:type: elaboration
 */
 class myclass;
 pure virtual task pure_task1;


### PR DESCRIPTION
The test type should be `simulation` because this test detects semantic error.

Signed-off-by: Naoya Hatta <dalance@gmail.com>