### PR TITLE
Remove bp_lce from black-parrot test list

### DIFF
--- a/generators/black-parrot
+++ b/generators/black-parrot
@@ -68,10 +68,6 @@ lists = [
         'top': 'bp_cce',
         'flist': 'bp_top/syn/flist.vcs'
     }, {
-        'name': 'bp_lce',
-        'top': 'bp_lce',
-        'flist': 'bp_top/syn/flist.vcs'
-    }, {
         'name': 'bp_uce',
         'top': 'bp_uce',
         'flist': 'bp_top/syn/flist.vcs'


### PR DESCRIPTION
The bp_lce module is not valid as a top-level target; it has parameters that are defaulted to "inv" which results in invalid accesses later in the code. The module needs to be instantiated as part of larger design with valid parameter values, so it doesn't make sense to test in isolation.