### PR TITLE
Fix event_sequence test

### DIFF
--- a/tests/chapter-9/9.4.2.4--event_sequence.sv
+++ b/tests/chapter-9/9.4.2.4--event_sequence.sv
@@ -14,11 +14,11 @@
 :type: simulation parsing
 */
 module seq_tb ();
-	wire a = 0;
-	wire b = 0;
-	wire c = 0;
-	wire y = 0;
-	wire clk = 0;
+	logic a = 0;
+	logic b = 0;
+	logic c = 0;
+	logic y = 0;
+	logic clk = 0;
 
 	sequence seq;
 		@(posedge clk) a ##1 b ##1 c;


### PR DESCRIPTION
Assigning to nets from a procedural context is not allowed, so make them variables instead.

Example error:
```
../..tests/chapter-9/9.4.2.4--event_sequence.sv:30:10: error: cannot assign to a net within a procedural context
				@seq y = 1;
				     ^
```