### PR TITLE
Add history graph util

### DIFF
--- a/.github/workflows/summary.sh
+++ b/.github/workflows/summary.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 ANALYZER=$PWD"/tools/report_analyzer.py"
+GRAPHER=$PWD"/tools/history-graph"
 OUT_DIR=$PWD"/out/report/"
 COMPARE_REPORT=$OUT_DIR"/report.csv"
-BASE_REPORT=$OUT_DIR"/base_report.csv"
+REPORTS_HISTORY=$OUT_DIR"/history"
+BASE_REPORT=$OUT_DIR"/history/report.csv"
 CHANGES_SUMMARY_JSON=$OUT_DIR"/tests_summary.json"
 CHANGES_SUMMARY_MD=$OUT_DIR"/tests_summary.md"
 
@@ -23,7 +25,7 @@ hash -r
 conda info -a
 
 # Get base report from sv-tests master run
-wget https://chipsalliance.github.io/sv-tests-results/report.csv -O $BASE_REPORT
+git clone https://github.com/chipsalliance/sv-tests-results.git --depth 120 $REPORTS_HISTORY
 
 # Delete headers from all report.csv
 for file in $(find ./out/report_* -name "*.csv" -print); do
@@ -37,6 +39,9 @@ cat $(find ./out/report_* -name "*.csv" -print) >> $COMPARE_REPORT
 sed -i 1i\ $(head -1 $(find ./out/report_* -name "*.csv.backup" -print -quit)) $COMPARE_REPORT
 
 python $ANALYZER $COMPARE_REPORT $BASE_REPORT -o $CHANGES_SUMMARY_JSON -t $CHANGES_SUMMARY_MD
+
+# generate history graph
+python $GRAPHER -n 120 -r $REPORTS_HISTORY
 
 set +e
 set +x

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -86,19 +86,19 @@ jobs:
           chmod 700 ~/.ssh
           ./.github/workflows/update_report.sh
       - name: Prepare artifacts for PR commenter
-        if: github.event.workflow_run.event == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           mkdir tests_summary
           echo ${{ github.event.number }} > tests_summary/issue_num
           cp out/report/tests_summary.md tests_summary/
       - uses: actions/upload-artifact@v2
-        if: github.event.workflow_run.event == 'pull_request'
+        if: github.event_name == 'pull_request'
         with:
           name: tests_summary
           path: |
             ./tests_summary/
       - id: get-artifacts-to-delete
-        if: github.event.workflow_run.event == 'pull_request'
+        if: github.event_name == 'pull_request'
         run: |
           artifacts=$(find ./out -type d -name 'report_*' -exec basename {} \;)
           echo $artifacts
@@ -108,7 +108,7 @@ jobs:
           echo ::set-output name=artifacts::$artifacts
           echo $artifacts
       - name: Delete Old Artifacts
-        if: github.event.workflow_run.event == 'pull_request'
+        if: github.event_name == 'pull_request'
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ steps.get-artifacts-to-delete.outputs.artifacts }}

--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+</head>
+
+<body>
+    <canvas id="line-chart" width=300" height="150"></canvas>
+    <script>
+
+    new Chart(document.getElementById("line-chart"), {
+      type: 'line',
+      data: {
+        labels: [ {{ labels }} ],
+        datasets: [
+          {% for tool in datasets %}
+            {
+              data: [ {{ datasets[tool] }} ],
+              label: "{{ tool }}" ,
+              borderColor: "{{ colors[tool] }}",
+              fill: false
+            },
+          {% endfor %}
+        ]
+      },
+      options: {
+        title: {
+          display: true,
+          text: 'SV-Tests results history'
+        }
+      }
+    });
+    </script>
+</body>
+</html>
+

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -7,4 +7,5 @@ psutil
 mako
 make_var
 pytablewriter
+GitPython
 git+https://github.com/lowRISC/fusesoc.git@ot

--- a/tools/history-graph
+++ b/tools/history-graph
@@ -15,6 +15,7 @@ import sys
 import jinja2
 import datetime
 import argparse
+import binascii
 
 from git import Repo
 from random import randint
@@ -91,8 +92,8 @@ for tool in datasets:
 # randomize colors
 colors = dict()
 for tool in datasets:
-    r, g, b = randint(0, 255), randint(0, 255), randint(0, 255)
-    colors[tool] = '#%02x%02x%02x' % (r, g, b)
+    color = hex(binascii.crc32(tool.encode('utf-8')))[-6:]
+    colors[tool] = f'#{color:0<6.6}'
 
 try:
     with open(args.template) as f:

--- a/tools/history-graph
+++ b/tools/history-graph
@@ -54,15 +54,10 @@ args = parser.parse_args()
 
 def single_report_data(index, csv_file, data):
     with io.BytesIO(csv_file.data_stream.read()) as f:
-        reader = csv.reader(io.StringIO(f.read().decode('utf-8')))
+        reader = csv.DictReader(io.StringIO(f.read().decode('utf-8')))
         for r in reader:
-            # skip header
-            if r[1] == 'Tool':
-                continue
-            if 'False' in r[2]:
-                data[r[1]][index]['fail'] += 1
-            else:
-                data[r[1]][index]['pass'] += 1
+            key = 'pass' if r['Pass'] == 'True' else 'fail'
+            data[r['Tool']][index][key] += 1
 
 
 repo = Repo(args.results_dir)

--- a/tools/history-graph
+++ b/tools/history-graph
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import io
+import csv
+import sys
+import jinja2
+import datetime
+import argparse
+
+from git import Repo
+from random import randint
+from collections import defaultdict
+
+parser = argparse.ArgumentParser()
+
+data = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+
+parser.add_argument(
+    '-r',
+    '--results-dir',
+    help='Directory with the test results repository',
+    required=True)
+
+parser.add_argument(
+    '-n',
+    '--number-of-commits',
+    help='Number of commits in the history to process',
+    type=int,
+    default=120)
+
+parser.add_argument(
+    '--template',
+    help='Path to the html template',
+    default='conf/report/history-graph-template.html')
+
+parser.add_argument(
+    '-o',
+    '--out',
+    help='Path to the html file with the history graph',
+    default='out/report/history.html')
+
+# parse args
+args = parser.parse_args()
+
+
+def single_report_data(index, csv_file, data):
+    with io.BytesIO(csv_file.data_stream.read()) as f:
+        reader = csv.reader(io.StringIO(f.read().decode('utf-8')))
+        for r in reader:
+            # skip header
+            if r[1] == 'Tool':
+                continue
+            if 'False' in r[2]:
+                data[r[1]][index]['fail'] += 1
+            else:
+                data[r[1]][index]['pass'] += 1
+
+
+repo = Repo(args.results_dir)
+main_hash = repo.head.object.hexsha
+
+for i in range(args.number_of_commits, -1, -1):
+    current_hash = f'{main_hash}~{i}'
+    commit = repo.commit(current_hash)
+    print(f'Processing {commit}')
+
+    date = datetime.datetime.fromtimestamp(commit.committed_date)
+
+    targetfile = commit.tree / 'report.csv'
+    single_report_data(date, targetfile, data)
+
+datasets = defaultdict(list)
+
+for tool in data:
+    for index in data[tool]:
+        bad = data[tool][index]['fail']
+        good = data[tool][index]['pass']
+        percent = round(good * 100 / (good + bad), 2)
+        datasets[tool].append(percent)
+
+# convert lists to strings
+labels = ', '.join(f'"{x}"' for x in data[next(iter(data))].keys())
+
+for tool in datasets:
+    datasets[tool] = ', '.join(str(x) for x in datasets[tool])
+
+# randomize colors
+colors = dict()
+for tool in datasets:
+    r, g, b = randint(0, 255), randint(0, 255), randint(0, 255)
+    colors[tool] = '#%02x%02x%02x' % (r, g, b)
+
+try:
+    with open(args.template) as f:
+        template = jinja2.Template(
+            f.read(), trim_blocks=True, lstrip_blocks=True)
+except Exception as e:
+    print(f'Unable to read template: {e}')
+
+try:
+    with open(args.out, 'w') as f:
+        f.write(
+            template.render(labels=labels, datasets=datasets, colors=colors))
+except Exception as e:
+    print(f'Unable to generate history graph: {e}')

--- a/tools/history-graph
+++ b/tools/history-graph
@@ -68,7 +68,7 @@ def single_report_data(index, csv_file, data):
 repo = Repo(args.results_dir)
 main_hash = repo.head.object.hexsha
 
-for i in range(args.number_of_commits, -1, -1):
+for i in range(args.number_of_commits - 1, -1, -1):
     current_hash = f'{main_hash}~{i}'
     commit = repo.commit(current_hash)
     print(f'Processing {commit}')


### PR DESCRIPTION
Closes #1636

This adds a simple history graph (generated using commits from the sv-tests-results).

Currently it looks like this:
![2021-08-04-160931](https://user-images.githubusercontent.com/8438531/128196008-eaaab639-ce6d-458a-a96a-12ded27e725f.png)

It uses a MIT licensed https://www.chartjs.org/ library.

TODO:

- [x] Add a CI job that generates it
- [x] Publish it next to the original report
- [ ] Add links in the report to the history graph
