### PR TITLE
Don't upload all the output for the PR commenter

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -12,9 +12,6 @@ jobs:
     runs-on: ubuntu-18.04
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Prepare output directories
-        run: mkdir -p out/report
-
       - name: 'Download artifact'
         uses: actions/github-script@v3.1.0
         with:
@@ -38,12 +35,11 @@ jobs:
 
       - run: |
           unzip tests_summary.zip
-          tar xvf sv-tests-out.tar.bz2
-          cat ./out/report/tests_summary.md
+          cat ./tests_summary/tests_summary.md
 
       - id: get-comment-body
         run: |
-          body=$(cat ./out/report/tests_summary.md)
+          body=$(cat ./tests_summary/tests_summary.md)
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}"
@@ -51,7 +47,7 @@ jobs:
 
       - id: get-pr-number
         run: |
-          num=$(cat ./out/report/issue_num)
+          num=$(cat ./tests_summary/issue_num)
           echo ::set-output name=num::$num
 
       - name: Post comment

--- a/.github/workflows/compress.sh
+++ b/.github/workflows/compress.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Compressing tests logs
-tar -jcf sv-tests-out.tar.bz2 out/
-rm -rf out/
-mkdir out/
-mv sv-tests-out.tar.bz2 out/

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -85,16 +85,20 @@ jobs:
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           ./.github/workflows/update_report.sh
-      - name: Save PR number
+      - name: Prepare artifacts for PR commenter
+        if: github.event.workflow_run.event == 'pull_request'
         run: |
-          echo ${{ github.event.number }} > ./out/report/issue_num
-          ./.github/workflows/compress.sh
+          mkdir tests_summary
+          echo ${{ github.event.number }} > tests_summary/issue_num
+          cp out/report/tests_summary.md tests_summary/
       - uses: actions/upload-artifact@v2
+        if: github.event.workflow_run.event == 'pull_request'
         with:
           name: tests_summary
           path: |
-            ./out/
+            ./tests_summary/
       - id: get-artifacts-to-delete
+        if: github.event.workflow_run.event == 'pull_request'
         run: |
           artifacts=$(find ./out -type d -name 'report_*' -exec basename {} \;)
           echo $artifacts
@@ -104,6 +108,7 @@ jobs:
           echo ::set-output name=artifacts::$artifacts
           echo $artifacts
       - name: Delete Old Artifacts
+        if: github.event.workflow_run.event == 'pull_request'
         uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ steps.get-artifacts-to-delete.outputs.artifacts }}


### PR DESCRIPTION
It does not need the whole report, it is faster and saves us some quota
for the remaining artifacts where they are actually used.