### PR TITLE
History graph improvements

### DIFF
--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -53,4 +53,3 @@
     </script>
 </body>
 </html>
-

--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.0/dist/chart.min.js"></script>
 </head>
 
 <body>
@@ -24,11 +24,14 @@
         ]
       },
       options: {
-        title: {
-          display: true,
-          text: 'SV-Tests results history'
-        }
-      }
+        responsive: true,
+        plugins: {
+          title: {
+            display: true,
+            text: 'SV-Tests results history'
+          },
+        },
+      },
     });
     </script>
 </body>

--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -31,6 +31,22 @@
             text: 'SV-Tests results history'
           },
         },
+        scales: {
+          x: {
+            display: true,
+            title: {
+              display: true,
+              text: 'Date of the build'
+            }
+          },
+          y: {
+            display: true,
+            title: {
+              display: true,
+              text: 'Tests passed [%]'
+            },
+          }
+        }
       },
     });
     </script>

--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -8,6 +8,22 @@
   <canvas id="line-chart" width=300" height="150"></canvas>
   <script>
 
+    function handleHover(evt, item, legend) {
+      legend.chart.data.datasets.forEach((line) => {
+        line.borderColorOrig = line.borderColor;
+        if (item.text != line.label) {
+          line.borderColor = line.borderColor + "0c";
+        }
+      });
+      legend.chart.update();
+    };
+    function handleLeave(evt, item, legend) {
+      legend.chart.data.datasets.forEach((line) => {
+          line.borderColor = line.borderColorOrig;
+      });
+      legend.chart.update();
+    };
+
     new Chart(document.getElementById("line-chart"), {
       type: 'line',
       data: {
@@ -31,6 +47,10 @@
             display: true,
             text: 'SV-Tests results history'
           },
+          legend: {
+            onHover: handleHover,
+            onLeave: handleLeave
+          }
         },
         scales: {
           x: {

--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -5,8 +5,8 @@
 </head>
 
 <body>
-    <canvas id="line-chart" width=300" height="150"></canvas>
-    <script>
+  <canvas id="line-chart" width=300" height="150"></canvas>
+  <script>
 
     new Chart(document.getElementById("line-chart"), {
       type: 'line',
@@ -50,6 +50,6 @@
         }
       },
     });
-    </script>
+  </script>
 </body>
 </html>

--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -18,6 +18,7 @@
               data: [ {{ datasets[tool] }} ],
               label: "{{ tool }}" ,
               borderColor: "{{ colors[tool] }}",
+              stepped: true,
               fill: false
             },
           {% endfor %}


### PR DESCRIPTION
Changes:
* Added proper labels to x and y axis
* Changed the graph type to stepped (no diagonal lines, which suggest "guessing" what happened in between builds)
* When hovering the cursor over a tool name in the legend, all other tools are faded out - this makes it easier to identify the graph for a given tool, example below

![2021-08-13-154558](https://user-images.githubusercontent.com/8438531/129366616-994f2f39-5be0-42ad-b5cc-419bbeb66486.png)
