### PR TITLE
Add ivtest/program3b to blacklist

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -214,6 +214,10 @@ ivtest_file_exclude = [
     # Primitive port connections cannot use the '.name()' syntax
     'pr938b',
     'udp_dff',
+    # Icarus checks that final-blocks do not have non-blocking assignments but
+    # a strict reading of IEEE 1800-2017, $9.2.3 does not require this, even
+    # though the non-blocking assignment will have no effect.
+    'program3b',
 ]
 
 ivtest_long = ['comp1000', 'comp1001']


### PR DESCRIPTION
The Icarus test-case program3b wants non-blocking assignments in final-blocks to fail parsing.   A strict reading of 1800-2017 $9.2.3 does not require this, even though the non-blocking assignment will have no effect since there is no next tick in which the value will update.

Simulators do not handle this consistently:  VCS allows it, Questa disallows it, and Xcelium prints a warning.

Slang will also be handling this as a Warning.  See https://github.com/MikePopoloski/slang/discussions/405 and https://github.com/MikePopoloski/slang/pull/406