### PR TITLE
sv2v runner: support defines

### DIFF
--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -25,6 +25,9 @@ class Sv2v_zachjs(BaseRunner):
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)
 
+        for define in params['defines']:
+            self.cmd.append('-D' + define)
+
         self.cmd += params['files']
 
     def get_version(self):


### PR DESCRIPTION
Similar logic already exists in other runners. Relevant tests which previously failed now appear to pass. 