### PR TITLE
history: sort tools by name in legend

### DIFF
--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -29,7 +29,7 @@
       data: {
         labels: [ {{ labels }} ],
         datasets: [
-          {% for tool in datasets %}
+          {% for tool in datasets | sort %}
             {
               data: [ {{ datasets[tool] }} ],
               label: "{{ tool }}" ,


### PR DESCRIPTION
By default the sort done by jinja2 is not case sensitive.