### PR TITLE
Make Yosys, Yosys-SV and UHDM-Yosys runners equivalent

### DIFF
--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: ISC
 
 import os
-import shutil
+import sys
 
 from BaseRunner import BaseRunner
 
@@ -22,8 +22,6 @@ class UhdmYosys(BaseRunner):
         self.url = "https://github.com/alainmarcel/uhdm-integration"
 
     def prepare_run_cb(self, tmp_dir, params):
-        mode = params["mode"]
-        conf = os.environ["CONF_DIR"]
         runner_scr = os.path.join(tmp_dir, "scr.sh")
         yosys_scr = os.path.join(tmp_dir, "yosys-script")
 
@@ -33,9 +31,9 @@ class UhdmYosys(BaseRunner):
         with open(yosys_scr, "w") as f:
             f.write("read_uhdm slpp_all/surelog.uhdm\n")
 
-            # prep (without optimizations
+            # prep (without optimizations)
             f.write(
-                f"hierarchy -check -top \\{top}\n"
+                f"hierarchy -top \\{top}\n"
                 "proc\n"
                 "check\n"
                 "memory_dff\n"

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -24,6 +24,8 @@ class Yosys(BaseRunner):
         run = os.path.join(tmp_dir, "run.sh")
         scr = os.path.join(tmp_dir, 'scr.ys')
 
+        top = self.get_top_module_or_guess(params)
+
         inc = ""
         for incdir in params['incdirs']:
             inc += f' -I {incdir}'
@@ -36,6 +38,18 @@ class Yosys(BaseRunner):
         with open(scr, 'w') as f:
             for svf in params['files']:
                 f.write(f'read_verilog -sv {inc} {defs} {svf}\n')
+
+            # prep (without optimizations)
+            f.write(
+                f"hierarchy -top \\{top}\n"
+                "proc\n"
+                "check\n"
+                "memory_dff\n"
+                "memory_collect\n"
+                "stat\n"
+                "check\n"
+                "write_json\n"
+                "write_verilog\n")
 
         # prepare wrapper script
         with open(run, 'w') as f:

--- a/tools/runners/YosysSv.py
+++ b/tools/runners/YosysSv.py
@@ -24,6 +24,8 @@ class YosysSv(BaseRunner):
         run = os.path.join(tmp_dir, "run.sh")
         scr = os.path.join(tmp_dir, 'scr.ys')
 
+        top = self.get_top_module_or_guess(params)
+
         inc = ""
         for incdir in params['incdirs']:
             inc += f' -I {incdir}'
@@ -36,6 +38,18 @@ class YosysSv(BaseRunner):
         with open(scr, 'w') as f:
             for svf in params['files']:
                 f.write(f'read_verilog -sv {inc} {defs} {svf}\n')
+
+            # prep (without optimizations)
+            f.write(
+                f"hierarchy -top \\{top}\n"
+                "proc\n"
+                "check\n"
+                "memory_dff\n"
+                "memory_collect\n"
+                "stat\n"
+                "check\n"
+                "write_json\n"
+                "write_verilog\n")
 
         # prepare wrapper script
         with open(run, 'w') as f:


### PR DESCRIPTION
Currently the runner for UHDM-Yosys runs more commands than the ones for vanilla Yosys and Yosys-SV, which results in an unfair comparison. This PR adds the missing commands to the Yosys and Yosys-SV runners. It also removes the `-check` flag from the `hierarchy` command, as it would cause some tests to fail (like this one: https://chipsalliance.github.io/sv-tests-results/#UhdmYosys|utd-sv|utd-sv_bw_dtl_impctl_pulldown).

It also cleans up the UHDM-Yosys runner a bit (imports, unused vars).