### PR TITLE
Fix mailbox test variable declarations

### DIFF
--- a/tests/chapter-15/15.4--mailbox-blocking.sv
+++ b/tests/chapter-15/15.4--mailbox-blocking.sv
@@ -17,10 +17,10 @@ module top();
 mailbox m;
 
 initial begin
-	m = new();
 	string msg = "abc";
 	string r;
 	string r_peek;
+	m = new();
 	m.put(msg);
 	m.peek(r_peek);
 	$display(":assert: (%d == 1)", m.num());

--- a/tests/chapter-15/15.4--mailbox-non-blocking.sv
+++ b/tests/chapter-15/15.4--mailbox-non-blocking.sv
@@ -17,10 +17,10 @@ module top();
 mailbox m;
 
 initial begin
-	m = new();
 	string msg = "abc";
 	string r;
 	string r_peek;
+	m = new();
 	m.try_put(msg);
 	m.peek(r_peek);
 	$display(":assert: (%d == 1)", m.num());


### PR DESCRIPTION
The mailbox tests have a syntax problem where variables are defined after functional logic in the initial block.   Slang detects this and gives a valid error. The fix is to move the mailbox creation to be after the variable declarations.

```
tests/chapter-15/15.4--mailbox-blocking.sv:21:2: error: declaration must come before all statements in the block
        string msg = "abc";
        ^
```