### PR TITLE
Extract common partials from report and history templates

### DIFF
--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -2,9 +2,12 @@
 <html>
 <head>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.0/dist/chart.min.js"></script>
+  <link rel="stylesheet" type="text/css" href="history.css">
 </head>
 
 <body>
+  <button class="button-switcher button-switcher-history" onclick="location='https://chipsalliance.github.io/sv-tests-results/history'"> sv-tests results history </button>
+  <button class="button-switcher" onclick="location='https://chipsalliance.github.io/sv-tests-results/'"> sv-tests results </button>
   <canvas id="line-chart" width=300" height="150"></canvas>
   <script>
 

--- a/conf/report/history.css
+++ b/conf/report/history.css
@@ -1,0 +1,17 @@
+.button-switcher {
+  background-color: white;
+  color: black; 
+  border: 2px solid #4CAF60;
+  border-radius: 5px;
+  top: 10px;
+  font-size: auto;
+  float: right;
+  margin:5px;
+}
+
+.button-switcher-history {background-color: #4CAF60; color: white;}
+
+.button-switcher:hover {
+  background-color: #4CAF60;
+  color: white;
+}

--- a/conf/report/partials/body-begin.html
+++ b/conf/report/partials/body-begin.html
@@ -1,0 +1,5 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
+</head>
+<body>

--- a/conf/report/partials/body-end.html
+++ b/conf/report/partials/body-end.html
@@ -1,0 +1,4 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
+</body>

--- a/conf/report/partials/content-begin.html
+++ b/conf/report/partials/content-begin.html
@@ -1,5 +1,8 @@
 {% if False %}
 <!-- vim: set ts=2 sts=2 sw=2 et: -->
 {% endif %}
+<button class="button-switcher" onclick="location='https://chipsalliance.github.io/sv-tests-results/history'"> sv-tests results history </button>
+<button class="button-switcher button-switcher-report" onclick="location='https://chipsalliance.github.io/sv-tests-results/'"> sv-tests results </button>
+<br>
 <h1 class="headline"><a href="https://github.com/chipsalliance/sv-tests">SV-Tests</a></h1>
     <p class="headline"><a href="https://github.com/chipsalliance/sv-tests"><em>Test suite to check compliance with the SystemVerilog LRM by chapter as well as some real-world cores and test-cases.</em></a></p>

--- a/conf/report/partials/content-begin.html
+++ b/conf/report/partials/content-begin.html
@@ -1,0 +1,5 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
+<h1 class="headline"><a href="https://github.com/chipsalliance/sv-tests">SV-Tests</a></h1>
+    <p class="headline"><a href="https://github.com/chipsalliance/sv-tests"><em>Test suite to check compliance with the SystemVerilog LRM by chapter as well as some real-world cores and test-cases.</em></a></p>

--- a/conf/report/partials/content-end.html
+++ b/conf/report/partials/content-end.html
@@ -1,0 +1,18 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
+  <br>
+  <a class="download" href="report.csv">Download a summary in csv</a>
+  
+  <br> <br>
+  <footer id="footer">
+    Generated using <a href="https://github.com/chipsalliance/sv-tests">sv-tests</a>,
+    revision: <a href="https://github.com/chipsalliance/sv-tests/commit/{{revision}}">{{revision}}</a>,
+    {% if build_id != 'local' %}
+      {% set href = 'https://github.com/chipsalliance/sv-tests/actions/runs/' ~ build_id|string %}
+      build_id: <a href="{{href}}">{{build_id}}</a>,
+    {% else %}
+      build_id: <a>{{build_id}}</a>,
+    {% endif %}
+    date: <a>{{datetime}}</a>.
+  </footer>

--- a/conf/report/partials/page-begin.html
+++ b/conf/report/partials/page-begin.html
@@ -1,0 +1,9 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>{{ title }}</title>

--- a/conf/report/partials/page-end.html
+++ b/conf/report/partials/page-end.html
@@ -1,0 +1,4 @@
+{% if False %}
+<!-- vim: set ts=2 sts=2 sw=2 et: -->
+{% endif %}
+</html>

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -1,12 +1,9 @@
 {% if False %}
 <!-- vim: set ts=2 sts=2 sw=2 et: -->
 {% endif %}
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="UTF-8" />
-    <title>SystemVerilog Report</title>
 
+{% include "page-begin.html" %}
+    
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/themes/smoothness/jquery-ui.css">
@@ -18,9 +15,8 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" rel="stylesheet"/>
     <link rel="stylesheet" type="text/css" href="report.css">
     <script type="text/javascript" charset="utf8" src="report.js"></script>
-  </head>
-
-  <script>
+    
+    <script>
     var table;
     var toolnames = [];
     var tool_array = [];
@@ -371,10 +367,9 @@
       width: calc(80% / {{ report.keys()|length}} );
     }
   </style>
-
-  <body>
-    <h1 class="headline"><a href="https://github.com/chipsalliance/sv-tests">SV-Tests</a></h1>
-    <p class="headline"><a href="https://github.com/chipsalliance/sv-tests"><em>Test suite to check compliance with the SystemVerilog LRM by chapter as well as some real-world cores and test-cases.</em></a></p>
+    {% include 'body-begin.html' %}
+    {% include "content-begin.html" %}
+    
     <button onclick="toggleFilters()">Show advanced filters (experimental)</button>
     <section style="display: none;" id="filter">
       <ul class="filter-entries">
@@ -483,23 +478,10 @@
         </tr>
       </tfoot>
     </table>
-    <br>
-    <a class="download" href="report.csv">Download a summary in csv</a>
-  </body>
-
-  <br> <br>
-  <footer id="footer">
-    Generated using <a href="https://github.com/chipsalliance/sv-tests">sv-tests</a>,
-    revision: <a href="https://github.com/chipsalliance/sv-tests/commit/{{revision}}">{{revision}}</a>,
-    {% if build_id != 'local' %}
-      {% set href = 'https://github.com/chipsalliance/sv-tests/actions/runs/' ~ build_id|string %}
-      build_id: <a href="{{href}}">{{build_id}}</a>,
-    {% else %}
-      build_id: <a>{{build_id}}</a>,
-    {% endif %}
-    date: <a>{{datetime}}</a>.
-  </footer>
-
+    
+    {% include 'content-end.html' %}
+    
+    {% include 'body-end.html' %}
   <div id="logfile-outer">
     <div class="iframe-wrap">
       <iframe class="iframe-log" name="log-frame"></iframe>
@@ -540,4 +522,4 @@
     {% endfor %}
   </div>
 
-</html>
+{% include 'page-end.html' %}

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -480,8 +480,8 @@
     </table>
     
     {% include 'content-end.html' %}
-    
     {% include 'body-end.html' %}
+    
   <div id="logfile-outer">
     <div class="iframe-wrap">
       <iframe class="iframe-log" name="log-frame"></iframe>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -263,6 +263,25 @@ button:focus {outline:0;}
   left: 0;
 }
 
+.button-switcher {
+  background-color: white; 
+  color: black; 
+  border: 2px solid #4CAF60;
+  border-radius: 5px;
+  top: 10px;
+  font-size: 20px;
+  position:relative;
+  float: right;
+  margin:5px;
+}
+
+.button-switcher-report {background-color: #4CAF60; color: white;}
+
+.button-switcher:hover {
+  background-color: #4CAF60;
+  color: white;
+}
+
 footer {
   text-align: center;
   font-size: 10px;

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -54,6 +54,11 @@ parser.add_argument(
     default="conf/report/report-template.html")
 
 parser.add_argument(
+    "--partials",
+    help="Directory with report template partials",
+    default="conf/report/partials/")
+
+parser.add_argument(
     "--code-template",
     help="Path to the html code preview template",
     default="conf/report/code-template.html")
@@ -559,8 +564,9 @@ try:
             1 for t in rtt if rtt[t]["status"] not in "test-na")
 
     with open(args.template, "r") as f:
-        report = jinja2.Template(
-            f.read(), trim_blocks=True, lstrip_blocks=True)
+        loader = jinja2.FileSystemLoader(args.partials)
+        report = jinja2.Environment(
+            loader=loader, trim_blocks=True, lstrip_blocks=True).from_string(f.read())
 
     build_id = os.environ.get('GITHUB_RUN_ID', 'local')
     build_datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -571,6 +577,8 @@ try:
                 report=data,
                 database=database,
                 database_urls=urls,
+                #Partials
+                title="SystemVerilog Report",
                 revision=args.revision,
                 build_id=build_id,
                 datetime=build_datetime))


### PR DESCRIPTION
This PR extracts some partials from the the report and history templates in order include the common ones in both pages.
Additionally, buttons were added to enable seamless switching between the report and history pages.