### PR TITLE
Remove top module specifier for bp_lce and bp_uce tests

### DIFF
--- a/generators/black-parrot
+++ b/generators/black-parrot
@@ -69,11 +69,11 @@ lists = [
         'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_lce',
-        'top': 'bp_lce',
+        'top': '',
         'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_uce',
-        'top': 'bp_uce',
+        'top': '',
         'flist': 'bp_top/syn/flist.vcs'
     }, {
         'name': 'bp_unicore',


### PR DESCRIPTION
bp_lce and bp_uce are not valid top level modules according to the rules of SystemVerilog. slang correctly points this out:
```
error: 'bp_uce' is not a valid top-level module
```
Since everyone was so against removing these tests I propose just removing the top level specifier for them, which means nothing will be instantiated or elaborated for these tests. I don't see how it can work any other way without removing them completely.