### PR TITLE
Add tests from projf/projf-explore repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,3 +86,6 @@
 [submodule "third_party/tools/yosys-uhdm-plugin-integration"]
 	path = third_party/tools/yosys-uhdm-plugin-integration
 	url = https://github.com/antmicro/yosys-uhdm-plugin-integration.git
+[submodule "third_party/tests/projf-explore"]
+	path = third_party/tests/projf-explore
+	url = https://github.com/projf/projf-explore.git

--- a/conf/generators/meta-path/projf-explore.json
+++ b/conf/generators/meta-path/projf-explore.json
@@ -1,0 +1,8 @@
+{
+	"name": "projf",
+	"project": "projf-explore",
+	"paths": [
+		["tests", "projf-explore", "*", "*", "*"]
+	],
+	"matches": ["*.sv"]
+}


### PR DESCRIPTION
Signed-off-by: Tomasz Jurtsch <tjurtsch@antmicro.com>

This PR adds https://github.com/projf/projf-explore as submodule and template for path_generator