### PR TITLE
set verible action version to 'main'

### DIFF
--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -34,7 +34,7 @@ jobs:
       - run: |
           unzip event.json.zip
       - name: Run Verible action
-        uses: chipsalliance/verible-linter-action@v1.4
+        uses: chipsalliance/verible-linter-action@main
         with:
           paths:
             ./tests


### PR DESCRIPTION
We decided to keep the 'main' version until we make it stable, so I'm changing this.
We'll be able to apply fixes more easily.