### PR TITLE
Random collection of test fixes

### DIFF
--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -5,5 +5,5 @@
 		["tools", "yosys", "tests", "simple"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v"]
+	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v", "mem2reg_bounds_tern.v"]
 }

--- a/conf/generators/meta-path/yosys-svinterfaces.json
+++ b/conf/generators/meta-path/yosys-svinterfaces.json
@@ -5,5 +5,5 @@
 		["tools", "yosys", "tests", "svinterfaces"]
 	],
 	"matches": ["*.sv"],
-	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv"]
+	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv", "load_and_derive.sv", "ondemand.sv"]
 }

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -199,6 +199,7 @@ ivtest_file_exclude = [
     'no_timescale_in_module',
     'pr1704013',
     'scope2b',
+    'event_array',
     # $dumpvars with bit selects, doesn't appear to be legal and commercial tools disallow
     'array_word_check',
     'dump_memword',

--- a/tests/chapter-16/16.2--assert-final-uvm.sv
+++ b/tests/chapter-16/16.2--assert-final-uvm.sv
@@ -57,7 +57,7 @@ class env extends uvm_env;
             int a = 8'h35;
             m_if.a <= a;
 
-            assert final (m_if.a != m_if.b) else `uvm_error(label, $sformatf("assert failed :assert: (False)"));
+            assert final (m_if.a != m_if.b) else $error($sformatf("assert failed :assert: (False)"));
         end
         `uvm_info(label, "Finished run phase", UVM_LOW);
         phase.drop_objection(this);

--- a/tests/chapter-16/16.2--assert0-uvm.sv
+++ b/tests/chapter-16/16.2--assert0-uvm.sv
@@ -57,7 +57,7 @@ class env extends uvm_env;
             int a = 8'h35;
             m_if.a <= a;
 
-            assert #0 (m_if.a != m_if.b) else `uvm_error(label, $sformatf("assert failed :assert: (False)"));
+            assert #0 (m_if.a != m_if.b) else $error($sformatf("assert failed :assert: (False)"));
         end
         `uvm_info(label, "Finished run phase", UVM_LOW);
         phase.drop_objection(this);

--- a/tools/runner
+++ b/tools/runner
@@ -146,6 +146,7 @@ try:
 
         else:
             # set default values for optional metadata entries
+            test_params.setdefault('name', test)
             test_params.setdefault('files', test)
             test_params.setdefault('incdirs', os.path.dirname(test))
             test_params.setdefault('top_module', '')

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -56,6 +56,12 @@ class Slang(BaseRunner):
         if "black-parrot" in tags:
             self.cmd.append("--allow-use-before-declare")
 
+            # These two tests simply cannot be elaborated because they target
+            # modules that have invalid parameter values for a top-level module.
+            name = params["name"]
+            if 'bp_lce' in name or 'bp_uce' in name:
+                self.cmd.append("--parse-only")
+
         # The earlgrey core is not configured correctly and so references unknown modules
         # and packages. Only run parsing until that gets fixed.
         if "earlgrey" in tags:


### PR DESCRIPTION
Blacklisting one ivtest:
- event_array is marked as "should fail" but actually is totally fine (and passes in all major simulators)

Blacklisting three yosys tests:
- load_and_derive and ondemand appear to be helper files part of a larger test and do not pass in isolation (and also have some invalid syntax naming a module "ref" which is a keyword)
- mem2reg_bounds_tern references an out of bounds array element at compile time -- you could argue this should pass with a warning but it's a nonsensical operation

Two assert uvm tests were invalid; they had a begin/end pair as the action block of a deferred assertion, which is disallowed by the LRM:
```
../..tests/chapter-16/16.2--assert0-uvm.sv:60:47: error: deferred assertion action must be a subroutine call
            assert #0 (m_if.a != m_if.b) else `uvm_error(label, $sformatf("assert failed :assert: (False)"));
                                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../home/runner/work/sv-tests/sv-tests/third_party/tests/uvm/src/macros/uvm_message_defines.svh:153:4: note: expanded from macro 'uvm_error'
   begin \
   ^~~~~~~
```

Also tell the slang runner to only do parsing for the two black-parrot tests that cannot be elaborated due to invalid parameter values / top module listings.