### PR TITLE
More recategorization of tests after addition of elaboration mode

### DIFF
--- a/conf/generators/templates/encapsulation-fail.json
+++ b/conf/generators/templates/encapsulation-fail.json
@@ -7,7 +7,7 @@
 		":description: encapsulation test",
 		":should_fail_because: {1}",
 		":tags: 8.18",
-		":type: simulation",
+		":type: simulation elaboration",
 		"*/",
 		"module top();",
 		"class a_cls;",

--- a/conf/generators/templates/uvm-classes_0.sv
+++ b/conf/generators/templates/uvm-classes_0.sv
@@ -11,7 +11,7 @@
 :name: {0}_0
 :description: {0} class test
 :tags: uvm uvm-classes
-:type: simulation parsing
+:type: simulation elaboration parsing
 */
 
 import uvm_pkg::*;

--- a/conf/generators/templates/uvm-classes_1.sv
+++ b/conf/generators/templates/uvm-classes_1.sv
@@ -11,7 +11,7 @@
 :name: {0}_1
 :description: {0} class test
 :tags: uvm uvm-classes
-:type: simulation parsing
+:type: simulation elaboration parsing
 */
 
 import uvm_pkg::*;

--- a/conf/generators/templates/uvm-classes_3.sv
+++ b/conf/generators/templates/uvm-classes_3.sv
@@ -11,7 +11,7 @@
 :name: {0}_3
 :description: {0} class test
 :tags: uvm uvm-classes
-:type: simulation parsing
+:type: simulation elaboration parsing
 */
 
 import uvm_pkg::*;

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -20,7 +20,7 @@ templ = """/*
 :files: {1}
 :incdirs: {4}
 :tags: ivtest
-:type: parsing
+:type: elaboration parsing
 {2}
 {3}
 {5}
@@ -277,7 +277,7 @@ for l in ivtest_lists:
             for t in type_should_fail:
                 if re.match(t, line[1]):
                     should_fail_because = ':should_fail_because: this test was imported from ivtest and is designed to fail'
-                    type_ = ':type: simulation'
+                    type_ = ':type: simulation elaboration'
 
             timeout = ''
             if name in ivtest_long:

--- a/tests/chapter-11/11.4.2--unary_op_dec-sim.sv
+++ b/tests/chapter-11/11.4.2--unary_op_dec-sim.sv
@@ -10,7 +10,7 @@
 /*
 :name: unary_op_dec_sim
 :description: -- operator simulation test
-type: simulation parsing
+type: simulation elaboration parsing
 :tags: 11.4.2
 */
 module top();

--- a/tests/chapter-11/11.4.2--unary_op_inc-sim.sv
+++ b/tests/chapter-11/11.4.2--unary_op_inc-sim.sv
@@ -10,7 +10,7 @@
 /*
 :name: unary_op_inc_sim
 :description: ++ operator simulation test
-type: simulation parsing
+type: simulation elaboration parsing
 :tags: 11.4.2
 */
 module top();

--- a/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
+++ b/tests/chapter-11/11.9--tagged_union_member_access_inv.sv
@@ -12,7 +12,7 @@
 :description: invalid tagged union member access test
 :should_fail_because: accessing wrong member should result in run-time error
 :tags: 11.9
-:type: simulation elaboration
+:type: simulation
 */
 module top();
 

--- a/tests/chapter-16/16.10--property-local-var-fail.sv
+++ b/tests/chapter-16/16.10--property-local-var-fail.sv
@@ -11,7 +11,7 @@
 :name: property_local_var_fail_test
 :description: failing property with local variables
 :should_fail_because: pipeline increments value by 4 but property expects incrementation by 3
-:type: simulation elaboration
+:type: simulation
 :tags: 16.10
 */
 

--- a/tests/chapter-16/16.10--property-local-var-uvm-fail.sv
+++ b/tests/chapter-16/16.10--property-local-var-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: property_local_var_test_fail_uvm
 :description: failing property with local variables in UVM
 :should_fail_because: pipeline increments value by 4 but property expects incrementation by 3
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.10--sequence-local-var-fail.sv
+++ b/tests/chapter-16/16.10--sequence-local-var-fail.sv
@@ -11,7 +11,7 @@
 :name: sequence_local_var_fail_test
 :description: failing sequence with local variables
 :should_fail_because: pipeline increments value by 4 but sequence expects incrementation by 3
-:type: simulation elaboration
+:type: simulation
 :tags: 16.10
 */
 

--- a/tests/chapter-16/16.12--property-interface-uvm-fail.sv
+++ b/tests/chapter-16/16.12--property-interface-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: property_interface_test_fail_uvm
 :description: failing property in interface test with UVM
 :should_fail_because: mem_ctrl asserts read and write at the same time and property checks that one or the other is asserted
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.12--property-prec-uvm-fail.sv
+++ b/tests/chapter-16/16.12--property-prec-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: property_prec_test_fail_uvm
 :description: failing property with precondition in UVM
 :should_fail_because: mem_ctrl interleaves reads and writes and property requires to keep reading
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.12--property-uvm-fail.sv
+++ b/tests/chapter-16/16.12--property-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: property_test_fail_uvm
 :description: failing property test with UVM
 :should_fail_because: mem_ctrl asserts read and write at the same time and property checks that one or the other is asserted
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.14--assume-property-uvm-fail.sv
+++ b/tests/chapter-16/16.14--assume-property-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: assume_property_test_fail_uvm
 :description: failing assume property test with UVM
 :should_fail_because: dut asserts read and write at the same time
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.15--property-disable-iff-fail.sv
+++ b/tests/chapter-16/16.15--property-disable-iff-fail.sv
@@ -11,7 +11,7 @@
 :name: property_disable_iff_fail_test
 :description: failing property with disable iff
 :should_fail_because: disable iff uses wrong reset polarity
-:type: simulation elaboration
+:type: simulation
 :tags: 16.15
 */
 

--- a/tests/chapter-16/16.15--property-iff-uvm-fail.sv
+++ b/tests/chapter-16/16.15--property-iff-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: property_disable_iff_fail_test_uvm
 :description: failing property with disable iff test with UVM
 :should_fail_because: disable iff uses wrong reset polarity
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.17--expect-uvm-fail.sv
+++ b/tests/chapter-16/16.17--expect-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: expect_test_fail_uvm
 :description: failing expect in UVM
 :should_fail_because: read is asserted every 2 cycles
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.2--assume-uvm-fail.sv
+++ b/tests/chapter-16/16.2--assume-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: assume_test_fail_uvm
 :description: failing assume test with UVM
 :should_fail_because: adder returns wrong value and assume expects correct result (a+b)
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.7--sequence-intersect-uvm-fail.sv
+++ b/tests/chapter-16/16.7--sequence-intersect-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: sequence_intersect_op_test_fail_uvm
 :description: failing sequence with "intersect" operator in UVM
 :should_fail_because: intersecting sequences must start and end at the same time but gnt1 is asserted later
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.7--sequence-throughout-uvm-fail.sv
+++ b/tests/chapter-16/16.7--sequence-throughout-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: sequence_throughout_op_test_fail_uvm
 :description: failing sequence with "throughout" operator in UVM
 :should_fail_because: gnt2 is not asserted
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-16/16.7--sequence-uvm-fail.sv
+++ b/tests/chapter-16/16.7--sequence-uvm-fail.sv
@@ -11,7 +11,7 @@
 :name: sequence_test_fail_uvm
 :description: failing sequence in UVM
 :should_fail_because: mem_ctrl interleaves reads and writes and sequence requires to keep reading
-:type: simulation elaboration
+:type: simulation
 :tags: uvm uvm-assertions
 */
 

--- a/tests/chapter-20/20.14--coverage.sv
+++ b/tests/chapter-20/20.14--coverage.sv
@@ -11,7 +11,7 @@
 :name: coverage_routines
 :description: coverage routine test
 :tags: 20.14
-:type: simulation parsing
+:type: simulation elaboration parsing
 */
 
 module DUT;


### PR DESCRIPTION
This adds the elaboration mode to a bunch of tests that were missed when the big diff was landed (notably ivtests can elaborate just fine, and in addition most (all?) of the should_fail ivtests are things that should be caught at elaboration time so we shouldn't lose those tests).

Additionally I removed elaboration from a few tests that are truly sim-only because they require some kind of failure or value checking at runtime.