### PR TITLE
Fix sv2v version logic

### DIFF
--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -34,8 +34,5 @@ class Sv2v_zachjs(BaseRunner):
     def get_version(self):
         version = super().get_version()
 
-        # sv2v stores the actual version at the second position
-        revision = version.split()[1]
-
-        # return it without the trailing comma
-        return " ".join([self.name, revision[:-1]])
+        # return it with our custom prefix and without the trailing newline
+        return "zachjs-" + version.rstrip()


### PR DESCRIPTION
The logic here previously said it was dropping a trailing comma, but sv2v's version output doesn't have a trailing comma. On intermediate releases, this would simply drop one of the short hash digits. However, at version boundaries, the final digit of the version would be dropped, making something like `v0.0.9` become `v0.0.`.