### PR TITLE
Fixing broken link to 3rd-party utd-sv tests

### DIFF
--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -11,7 +11,7 @@ earlgrey	Lowrisc chip with Ibex core	https://github.com/lowRISC/opentitan
 fx68k	FX68K m68k core	https://github.com/ijor/fx68k
 yosys	Tests imported from Yosys	https://github.com/YosysHQ/yosys/tree/master/tests/hana
 hdlconv	Tests imported from hdlConvertor	https://github.com/Nic30/hdlConvertor/tree/master/tests
-utd-sv	Tests imported from utd-SystemVerilog	https://github.com/SymbiFlow/utd-sv/tree/8a188d0df42cfc6842cd73074ade8f5982620c7e
+utd-sv	Tests imported from utd-SystemVerilog	https://github.com/SymbiFlow/utd-sv
 uvm	Tests imported from UVM	https://github.com/SymbiFlow/uvm
 uvm-req	UVM Prerequisites
 uvm-assertions	UVM tests using assertions


### PR DESCRIPTION
This PR addresses #1827 and simply fixes a broken link. If there's a larger fix planned, such as to replace the submodule with the file copied over, feel free to reject this PR.

I am participating in [Hacktoberfest](https://hacktoberfest.digitalocean.com/), so if you do accept this change, would you mind adding the `hacktoberfest-accepted` tag to the PR so it counts towards that? Thanks!