### PR TITLE
CI: run lint-review in GHA runners

### DIFF
--- a/.github/workflows/lint-review.yml
+++ b/.github/workflows/lint-review.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   lint_review:
-    runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: 'Download artifact'


### PR DESCRIPTION
This check uses docker-container action that is currently unsupported in custom-runners

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>