### PR TITLE
CI: add missing tool filter; fix uhdm-yosys binary name

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -36,13 +36,17 @@ jobs:
             deps: autoconf autotools-dev bison flex libfl-dev
           - name: verilator-uhdm
             deps: autoconf autotools-dev bison default-jre flex libfl-dev cmake pkg-config tclsh uuid-dev
+            runners_filter: UhdmVerilator
           - name: yosys
             deps: bison clang tcl-dev flex libfl-dev
           - name: yosys-uhdm
             repo: yosys-uhdm-plugin-integration
             deps: cmake clang tcl-dev bison default-jre flex libfl-dev libreadline-dev pkg-config tclsh uuid-dev
+            runners_filter: UhdmYosys
           - name: zachjs-sv2v
             deps: haskell-stack
+    env:
+      RUNNERS_FILTER: ${{ matrix.tool.runners_filter }}
 
     name: ${{ matrix.tool.name }}
     runs-on: [self-hosted, Linux, X64]

--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -18,7 +18,7 @@ from BaseRunner import BaseRunner
 class UhdmYosys(BaseRunner):
     def __init__(self):
         super().__init__(
-            "uhdm-yosys", "uhdm-yosys",
+            "yosys-uhdm", "yosys-uhdm",
             {"preprocessing", "parsing", "elaboration"})
 
         self.url = "https://github.com/alainmarcel/uhdm-integration"


### PR DESCRIPTION
This PR adds tool filter for uhdm-verilator and uhdm-yosys tools and fixes uhdm-yosys binary name to expected one.