### PR TITLE
Generate unique test name in path_generator

### DIFF
--- a/generators/path_generator
+++ b/generators/path_generator
@@ -71,8 +71,9 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
 
     for path in paths:
         for match in matches:
-            for f in glob.glob(os.path.abspath(os.path.join(third_party_dir,
-                                                            *path, match))):
+            search_path = os.path.abspath(
+                os.path.join(third_party_dir, *path, match))
+            for f in glob.glob(search_path):
 
                 # make a copy of extra tags for a particular test
                 extra_tags = global_extra_tags[:]
@@ -80,8 +81,14 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
                 if blacklist.count(basename) > 0:
                     print("Skipping blacklisted file: {}".format(f))
                     continue
-
                 fname = name + '_' + os.path.basename(os.path.splitext(f)[0])
+                # check if this file is in folder inside test directory
+                folder_path = f.replace(
+                    os.path.commonprefix([f, search_path]), "")
+                folder_path = os.path.dirname(folder_path)
+                folder_path = folder_path.replace("/", "_")
+                if folder_path != "":
+                    fname = folder_path + "_" + fname
                 test_file = os.path.join(test_dir, fname + '.sv')
 
                 incs = os.path.dirname(f)

--- a/tests/chapter-14/14.3--clocking-block-signals-error.sv
+++ b/tests/chapter-14/14.3--clocking-block-signals-error.sv
@@ -8,7 +8,7 @@
 
 
 /*
-:name: clocking_block_signals
+:name: clocking_block_signals_fail
 :description: clocking block with signals test
 :should_fail_because: assigning to net from procedural context
 :type: simulation elaboration

--- a/tests/chapter-18/18.17.2--if-else-production-statements_0_fail.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_0_fail.sv
@@ -8,7 +8,7 @@
 
 
 /*
-:name: if_else_production_statements_0
+:name: if_else_production_statements_0_fail
 :description: randcase if-else test
 :should_fail_because: switch variable not declared
 :type: elaboration

--- a/tests/chapter-18/18.17.2--if-else-production-statements_2_fail.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_2_fail.sv
@@ -8,7 +8,7 @@
 
 
 /*
-:name: if_else_production_statements_2
+:name: if_else_production_statements_2_fail
 :description: randcase if-else test
 :should_fail_because: switch variable not declared
 :type: elaboration

--- a/tests/chapter-18/18.17.3--case-production-statements_0_fail.sv
+++ b/tests/chapter-18/18.17.3--case-production-statements_0_fail.sv
@@ -8,7 +8,7 @@
 
 
 /*
-:name: case_production_statements_0
+:name: case_production_statements_0_fail
 :description: randcase case statement test
 :should_fail_because: switch variable not declared
 :type: elaboration

--- a/tests/chapter-18/18.17.6--aborting-productions-break-and-return_2_fail.sv
+++ b/tests/chapter-18/18.17.6--aborting-productions-break-and-return_2_fail.sv
@@ -8,7 +8,7 @@
 
 
 /*
-:name: aborting_productions_break_and_return_2
+:name: aborting_productions_break_and_return_2_fail
 :description: return statement test
 :should_fail_because: typo in production name
 :type: elaboration


### PR DESCRIPTION
Currently all test cases from ``projf-explore/hello/hello-nexys/{A..I}/top.sv``are generated as: ``tests/generated/projf-explore/projf_top.sv``. This PR adds path from the test directory (with ``/`` changed to ``_``) to the name of the test and fixes this problem.

Now all test have unique test name.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>