### PR TITLE
25.3-interface.sv: Fix wrong top_module

### DIFF
--- a/tests/chapter-25/25.3-interface.sv
+++ b/tests/chapter-25/25.3-interface.sv
@@ -11,6 +11,7 @@
 :name: interface
 :description: interface test
 :tags: 25.3
+:top_module: top
 */
 
 interface test_bus;


### PR DESCRIPTION
Fixes 25.3-interface passing the wrong top-module to Verilator.
