### PR TITLE
Add -defer to yosys cmd in not elaboration tests only

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -20,7 +20,7 @@ templ = """/*
 :files: {1}
 :incdirs: {4}
 :tags: ivtest
-:type: elaboration parsing
+:type: simulation parsing
 {2}
 {3}
 {5}

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -25,6 +25,9 @@ class Yosys(BaseRunner):
         run = os.path.join(tmp_dir, "run.sh")
         scr = os.path.join(tmp_dir, 'scr.ys')
         mode = params['mode']
+        defer = ""
+        if mode != "elaboration":
+            defer = "-defer"
 
         top = self.get_top_module_or_guess(params)
 
@@ -39,7 +42,7 @@ class Yosys(BaseRunner):
         # prepare yosys script
         with open(scr, 'w') as f:
             for svf in params['files']:
-                f.write(f'read_verilog -defer -sv {inc} {defs} {svf}\n')
+                f.write(f'read_verilog {defer} -sv {inc} {defs} {svf}\n')
 
             if mode == "elaboration":
                 # prep (without optimizations)


### PR DESCRIPTION
This PR changes ``yosys`` cmd to add ``-defer`` option only when test is not marked as ``elaboration``. It makes ``yosys`` to fail on tests that uses e.g. ``$display`` with invalid/unsupported format specifier or on unsupported ``$finish`` call.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>