### PR TITLE
Fix moore-parse runner

### DIFF
--- a/tools/check-runners
+++ b/tools/check-runners
@@ -39,12 +39,9 @@ else:
 runners = list(sorted(runners))
 
 for runner in runners:
-    try:
-        module = import_module(runner)
-        runner_cls = getattr(module, runner)
-        runner_obj = runner_cls()
-    except Exception:
-        continue
+    module = import_module(runner)
+    runner_cls = getattr(module, runner)
+    runner_obj = runner_cls()
 
     new_path = [
         os.path.abspath(os.environ['OUT_DIR'] + "/runners/bin/"),

--- a/tools/runners/moore.py
+++ b/tools/runners/moore.py
@@ -14,11 +14,12 @@ from BaseRunner import BaseRunner
 
 
 class moore(BaseRunner):
-    def __init__(self, name="moore"):
+    def __init__(
+            self,
+            name="moore",
+            supported_features={'preprocessing', 'parsing'}):
         super().__init__(
-            name,
-            executable="moore",
-            supported_features={'preprocessing', 'parsing'})
+            name, executable="moore", supported_features=supported_features)
 
         self.url = "http://llhd.io/"
 


### PR DESCRIPTION
This PR fixes ``moore-parse`` runner and disables caching exception when loading runner module in ``check-runner``.