### PR TITLE
Report: Reimplement test preview panel, reduce index.html file size

### DIFF
--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -1,3 +1,5 @@
+<!DOCTYPE html>
+<html>
 <head>
   <style>
     .log { font-family: "Courier New", Consolas, monospace; font-size: 80%; }
@@ -6,25 +8,26 @@
   </style>
 </head>
 <body>
-<h3><a href="{{runner_url}}" target="_blank">{{runner}}</a></h3>
-<pre class="{{status}}">
-description: {{description|e}}
-rc: {{rc|e}} (means success: {{tool_success|e}})
+<h3><a href="{{log['runner_url']}}" target="_blank">{{log['runner']|e}}</a></h3>
+<pre class="{{result.status}}">
+description: {{log['description']|e}}
+rc: {{result.exit_code}} (means success: {{log['tool_success']|e}})
 {% if should_fail_because|length %}
-should_fail_because: {{should_fail_because|e}}
+should_fail_because: {{log['should_fail_because']|e}}
 {% endif %}
-tags: {{tags|e}}
-incdirs: {{incdirs|e}}
-top_module: {{top_module|e}}
-type: {{type|e}}
-mode: {{mode|e}}
-files: {{file_urls}}
-defines: {{defines|e}}
-completed: {{date_completed}}
-time_elapsed: {{'%0.3f'| format(time_elapsed|float)}}s
-ram usage: {{'%d'| format(ram_usage|int)}} KB
+tags: {{result.tags|join(' ')|e}}
+incdirs: {{log['incdirs']|e}}
+top_module: {{log['top_module']|e}}
+type: {{result.types|join(' ')|e}}
+mode: {{log['mode']|e}}
+files:{% for f, f_html in input_files_map.items() %} <a href="{{f_html}}" target="file-frame">{{f|e}}</a>{% endfor +%}
+defines: {{log['defines']|e}}
+completed: {{log['date_completed']|e}}
+time_elapsed: {{'%0.3f'| format(result.total_time|float)}}s
+ram usage: {{'%d'| format(result.ram_usage|int)}} KB
 </pre>
 <pre class="log">
-{{log_urls}}
+{{content}}
 </pre>
 </body>
+</html>

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -15,10 +15,10 @@
 
     {# Global parameters for scripts and stylesheets #}
     <script>
-      var TOOL_NAMES = [{{'"' ~ report.keys()|sort|join('", "') ~ '"'}}];
-      var TOOLS_COUNT = {{report|length}};
+      var TOOL_NAMES = [{{report.tools.keys()|sort|map('escape_js_str')|map('quote')|join(', ')}}];
+      var TOOLS_COUNT = {{report.tools|length}};
     </script>
-    <style>:root { --TOOLS_COUNT: {{report|length}}; }</style>
+    <style>:root { --TOOLS_COUNT: {{report.tools|length}}; }</style>
 
     <link rel="stylesheet" type="text/css" href="report.css">
     <script type="text/javascript" charset="utf8" src="report.js"></script>
@@ -47,100 +47,106 @@
           <tr>
             <th></th>
             <th></th>
-            {% for tool, tooldata in report|dictsort %}
-            <th title="{{report[tool]['version']|e|replace('\n', '&#10;')}}" style="--z: {{loop.length - loop.index}}">
-              <a class="tool_link" target="_blank" href="{{report[tool]["url"]}}">{{tool|e}}</a>
+            {% for tool, tool_results in report.tools|dictsort %}
+            <th title="{{tool_results.version|escape_attr}}" style="--z: {{loop.length - loop.index}}">
+              <a class="tool_link" target="_blank" href="{{tool_results.url}}">{{tool|e}}</a>
             </th>
             {% endfor %}
           </tr>
         </thead>
         <tbody>
-          {% for tag, info in database|dictsort %}
+          {% for tag, tag_info in report.tags|dictsort %}
           {%   set types_used_in_the_row = [] %}
-          {%   for tool, tooldata in report|dictsort %}
-          {%     for type in tooldata["tags"][tag]["type"] %}
-          {%       if type not in types_used_in_the_row %}
-          {%         set _ = types_used_in_the_row.append(type) %}
-          {%       endif %}
-          {%     endfor %}
+          {%   for tool, tool_results in report.tools|dictsort %}
+          {%     if tag in tool_results.tags %}
+          {%       for type in tool_results.tags[tag].types %}
+          {%         if type not in types_used_in_the_row %}
+          {%           set _ = types_used_in_the_row.append(type) %}
+          {%         endif %}
+          {%       endfor %}
+          {%     endif %}
           {%   endfor %}
           <tr class="{{types_used_in_the_row|join(' ')}}" data-tag="{{tag|e}}">
-            <th title="{{info|e|replace('\n', '&#10;')}}">
-              {%- if tag in database_urls -%}
-              <a class="tag_link" target="_blank" href="{{database_urls[tag]}}">{{info|e}}</a>
+            <th title="{{tag_info.description|escape_attr}}">
+              {%- if tag_info.url -%}
+              <a class="tag_link" target="_blank" href="{{tag_info.url}}">{{tag_info.description|e}}</a>
               {%- else -%}
-              {{info|e}}
+              {{tag_info.description|e}}
               {%- endif -%}
             </th>
-            <th title="{{info|e|replace('\n', '&#10;')}}">{{tag|e}}</th>
-            {% for tool, tooldata in report|dictsort %}
-            {%   set test_data = tooldata['tags'][tag] %}
-            {%   set test_status = test_data['status'] %}
+            <th title="{{tag_info.description|escape_attr}}">{{tag|e}}</th>
+            {% for tool, tool_results in report.tools|dictsort %}
             {%   set attrs = [] %}
-            {%   if test_status != 'test-na' %}
-            {%     set head_test = test_data['logs'][test_data['head_test']]['name'] %}
-            {%     set _ = attrs.append('class="'~test_status~'"') %}
-            {%     set _ = attrs.append('data-tool="'~(tool|e)~'"') %}
-            {%     set _ = attrs.append('data-head-test="'~(head_test|e)~'"') %}
-            {%     if test_status == 'test-varied' %}
-            {%       set percentage = '%0.0f'|format(100.0 * test_data['passed-num'] / test_data['logs']|length) %}
-            {%       set _ = attrs.append('style="--val: '~(percentage)~'%"') %}
+            {%   if tag in tool_results.tags %}
+            {%     set tag_results = tool_results.tags[tag] %}
+            {%     set test_status = tag_results.status|string %}
+            {%     if test_status != 'test-na' %}
+            {%       set head_test = tag_results.tests[0].name %}
+            {%       set _ = attrs.append('class=' ~ (test_status|quote)) %}
+            {%       set _ = attrs.append('data-tool=' ~ (tool|escape_attr|quote)) %}
+            {%       set _ = attrs.append('data-head-test=' ~ (head_test|escape_attr|quote)) %}
+            {%       if test_status == 'test-varied' %}
+            {%         set percentage = '%0.0f'|format(100.0 * tag_results.passed_tests / tag_results.tests|length) %}
+            {%         set _ = attrs.append('style="--val: '~(percentage)~'%"') %}
+            {%       endif %}
             {%     endif %}
-            <td {{attrs|join(' ')}}>{{test_data['passed-num']}}/{{test_data['logs']|length}}</td>
+            {%   endif %}
+            {%   if attrs|length %}
+            <td {{attrs|join(' ')}}>{{tag_results.passed_tests}}/{{tag_results.tests|length}}</td>
             {%   else %}
             <td></td>
             {%   endif %}
             {% endfor %}
           </tr>
-        {% endfor %}
+          {% endfor %}
         </tbody>
         <tfoot>
           <tr>
             <th colspan="2">Total tests passed</th>
-            {% for tool, tooldata in report|dictsort %}
-            {%   set passed_tests = tooldata['total']['tests'] %}
-            {%   set total_tests = tooldata['tests']|length %}
+            {% for tool, tool_results in report.tools|dictsort %}
+            {%   set passed_tests = tool_results.total_passed_tests %}
+            {%   set total_tests = tool_results.total_tests %}
             {%   set passed_tests_percentage = '%0.0f'|format(100.0 * passed_tests / total_tests) %}
             <td class="test-varied" style="--val: {{passed_tests_percentage}}%" title="{{tool|lower|e}} ({{passed_tests_percentage}}%)">{{passed_tests}}/{{total_tests}}</td>
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Total tags passed</th>
-            {% for tool, tooldata in report|dictsort %}
-            {%   set passed_tags = tooldata['total']['tags'] %}
-            {%   set tested_tags = tooldata['total']['tested_tags'] %}
+            {% for tool, tool_results in report.tools|dictsort %}
+            {%   set passed_tags = tool_results.total_passed_tags %}
+            {%   set tested_tags = tool_results.total_tested_tags %}
             {%   set passed_tags_percentage = '%0.0f'|format(100.0 * passed_tags / tested_tags) %}
             <td class="test-varied" style="--val: {{passed_tags_percentage}}%" title="{{tool|lower|e}} ({{passed_tags_percentage}}%)">{{passed_tags}}/{{tested_tags}}</td>
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Total time elapsed</th>
-            {% for tool, tooldata in report|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tooldata["time_elapsed"])}}s</td>
+            {% for tool, tool_results in report.tools|dictsort %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.total_time)}}s</td>
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">User time elapsed</th>
-            {% for tool, tooldata in report|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tooldata["user_time"])}}s</td>
+            {% for tool, tool_results in report.tools|dictsort %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.user_time)}}s</td>
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">System time elapsed</th>
-            {% for tool, tooldata in report|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tooldata["system_time"])}}s</td>
+            {% for tool, tool_results in report.tools|dictsort %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.system_time)}}s</td>
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Maximum ram usage</th>
-            {% for tool, tooldata in report|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tooldata["ram_usage"])}} MB</td>
+            {% for tool, tool_results in report.tools|dictsort %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.max_ram_usage)}} MB</td>
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Average throughput passed for inputs &gt; 1KiB</th>
-            {% for tool, tooldata in report|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tooldata["passed_throughput"]|float)}} KiB/s</td>
+            {% for tool, tool_results in report.tools|dictsort %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.passed_throughput|float)}} KiB/s</td>
             {% endfor %}
           </tr>
         </tfoot>
@@ -169,18 +175,18 @@
       <div class="iframe-wrap">
         <iframe class="iframe-log" name="file-frame"></iframe>
       </div>
-      {% for tag, info in database.items() %}
-      {%   for tool, tooldata in report.items() %}
-      {%     if "test-na" not in tooldata["tags"][tag]["status"] %}
+      {% for tag in report.tags|sort %}
+      {%   for tool, tool_results in report.tools|dictsort %}
+      {%     if (tag in tool_results.tags) and (tool_results.tags[tag].status != 'test-na') %}
       <div id="{{tool}}-{{tag}}-logfile" class="logfile">
         <div id="logtab-{{tool}}-{{tag}}-bar" class="logtab-bar">
           <button class="logtab-btn logtab-close-btn" onclick="toggleLog('{{tool}}', '{{tag}}', null)">close</button>
-          {% for test, output in tooldata["tags"][tag]["logs_sorted"] %}
-          <button id="logtab-btn-{{tool}}-{{tag}}-{{output['name']}}" class="logtab-btn logtab-tab-btn {{output["status"]}} sorted" {#
-               #} onclick="selectTab('{{output['fname']}}', {#
-                                   #}'logtab-btn-{{tool}}-{{tag}}-{{output['name']}}', {#
-                                   #}'{{output['first_file']}}', {#
-                                   #}'{{output['name']}}')">{{output["name"]}}</button>
+          {% for test_result in tool_results.tags[tag].tests %}
+          <button id="logtab-btn-{{tool}}-{{tag}}-{{test_result.name}}" class="logtab-btn logtab-tab-btn {{test_result.status}} sorted" {#
+               #} onclick="selectTab('{{test_result.log_html_file}}', {#
+                                   #}'logtab-btn-{{tool}}-{{tag}}-{{test_result.name}}', {#
+                                   #}'{{test_result.input_files[0]}}.html', {#
+                                   #}'{{test_result.name}}')">{{test_result.name}}</button>
           {% endfor %}
         </div>
       </div>

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -147,7 +147,7 @@
       </table>
       <section id="summary-section">
         <a href="report.csv">Download a summary in csv</a>
-      </div>
+      </section>
     </main>
     <footer id="footer">
       <p>

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -74,17 +74,15 @@
               {{tag_info.description|e}}
               {%- endif -%}
             </th>
-            <th title="{{tag_info.description|escape_attr}}">{{tag|e}}</th>
+            <th title="{{tag_info.description|escape_attr}}">{{tag|lower|e}}</th>
             {% for tool, tool_results in report.tools|dictsort %}
             {%   set attrs = [] %}
             {%   if tag in tool_results.tags %}
             {%     set tag_results = tool_results.tags[tag] %}
             {%     set test_status = tag_results.status|string %}
             {%     if test_status != 'test-na' %}
-            {%       set head_test = tag_results.tests[0].name %}
             {%       set _ = attrs.append('class=' ~ (test_status|quote)) %}
-            {%       set _ = attrs.append('data-tool=' ~ (tool|escape_attr|quote)) %}
-            {%       set _ = attrs.append('data-head-test=' ~ (head_test|escape_attr|quote)) %}
+            {%       set _ = attrs.append('data-tool=' ~ (tool|lower|escape_attr|quote)) %}
             {%       if test_status == 'test-varied' %}
             {%         set percentage = '%0.0f'|format(100.0 * tag_results.passed_tests / tag_results.tests|length) %}
             {%         set _ = attrs.append('style="--val: '~(percentage)~'%"') %}
@@ -168,31 +166,15 @@
       </p>
     </footer>
 
-    <div id="logfile-outer">
-      <div class="iframe-wrap">
-        <iframe class="iframe-log" name="log-frame"></iframe>
+    <div class="c_test-details-panel s_hidden">
+      <iframe class="p_log" name="log-frame"></iframe>
+      <iframe class="p_file" name="file-frame"></iframe>
+      <div class="p_tests-list">
+        <template class="p_item-template">
+          <button class="p_item"><slot name="test-name"></slot></button>
+        </template>
+        <button class="p_close-button">close</button>
       </div>
-      <div class="iframe-wrap">
-        <iframe class="iframe-log" name="file-frame"></iframe>
-      </div>
-      {% for tag in report.tags|sort %}
-      {%   for tool, tool_results in report.tools|dictsort %}
-      {%     if (tag in tool_results.tags) and (tool_results.tags[tag].status != 'test-na') %}
-      <div id="{{tool}}-{{tag}}-logfile" class="logfile">
-        <div id="logtab-{{tool}}-{{tag}}-bar" class="logtab-bar">
-          <button class="logtab-btn logtab-close-btn" onclick="toggleLog('{{tool}}', '{{tag}}', null)">close</button>
-          {% for test_result in tool_results.tags[tag].tests %}
-          <button id="logtab-btn-{{tool}}-{{tag}}-{{test_result.name}}" class="logtab-btn logtab-tab-btn {{test_result.status}} sorted" {#
-               #} onclick="selectTab('{{test_result.log_html_file}}', {#
-                                   #}'logtab-btn-{{tool}}-{{tag}}-{{test_result.name}}', {#
-                                   #}'{{test_result.input_files[0]}}.html', {#
-                                   #}'{{test_result.name}}')">{{test_result.name}}</button>
-          {% endfor %}
-        </div>
-      </div>
-      {%     endif %}
-      {%   endfor %}
-      {% endfor %}
     </div>
   </body>
 </html>

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -10,7 +10,8 @@ body {
 
   font-family: sans-serif;
   margin: 0;
-  padding: 0;
+  /* --panel-height is set dynamically in report.js */
+  padding: 0 0 var(--panel-height, 0) 0;
 }
 
 main {
@@ -234,7 +235,7 @@ table.dataTable > tbody > tr > td:not(:empty) {
   font-weight: normal;
 }
 
-.test-cell-selected {
+table.dataTable > tbody > tr > td:not(:empty).s_selected {
   outline: 3px solid blue;
   filter: brightness(95%);
   font-weight: bold;
@@ -290,6 +291,82 @@ a.tool_link:hover, a.tag_link:hover {
   text-decoration-color: #00006f80;
 }
 
+/** Details panel *****************************************************/
+
+.c_test-details-panel {
+  position: fixed;
+  left: 1.5%;
+  right: 1.5%;
+  bottom: 0;
+  z-index: 10;
+
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px 2px;
+  grid-template-areas:
+    "log file"
+    "tests-list tests-list";
+  justify-content: stretch;
+  justify-items: stretch;
+
+  overflow-y: hidden;
+  overflow-x: hidden;
+
+  background-color: #000;
+  border: 2px solid black;
+  font-family: "Courier New", Courier, monospace;
+}
+
+.c_test-details-panel.s_hidden {
+  display: none;
+}
+
+.c_test-details-panel > .p_log { grid-area: log; }
+.c_test-details-panel > .p_file { grid-area: file; }
+.c_test-details-panel > .p_tests-list { grid-area: tests-list; }
+
+.c_test-details-panel > iframe {
+  background-color: #fff;
+  border: none;
+  height: 20vh;
+}
+
+.c_test-details-panel > .p_tests-list {
+  max-height: 20vh;
+  background-color: #666;
+  overflow-y: scroll;
+}
+
+.c_test-details-panel > .p_tests-list > button {
+  width: 12.5%;
+  margin: 0px;
+  cursor: pointer;
+  border: 2px solid #666;
+  overflow:hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  box-sizing: border-box;
+}
+
+.c_test-details-panel .p_close-button {
+  background: #cfcece;
+  float: right;
+}
+
+.c_test-details-panel > .p_tests-list > .p_item {
+  float: left;
+  background-color: #ff6961;
+}
+
+.c_test-details-panel > .p_tests-list > .p_item.s_passed {
+  background-color: #89E894;
+}
+
+.c_test-details-panel > .p_tests-list > .p_item.s_selected {
+  border: 2px solid blue;
+  font-weight: bold;
+}
+
 /** Other *************************************************************/
 
 .ui-widget-shadow {
@@ -307,87 +384,6 @@ a.tool_link:hover, a.tag_link:hover {
 
 .ui-corner-all {
   border-radius: 0px;
-}
-
-#logfile-outer {
-  display: none;
-  position: fixed;
-  bottom: 0;
-  left: 1.5%;
-  width: 97%;
-  max-height: 80%;
-  border: 2px solid black;
-  overflow-y: hidden;
-  overflow-x: hidden;
-  z-index: 10;
-  font-family: "Courier New", Courier, monospace;
-  background-color: #fff;
-}
-.logfile {
-  display: none;
-  max-height: 20%;
-  border: 2px solid black;
-  overflow-y: hidden;
-  overflow-x: hidden;
-  z-index: 10;
-  font-family: "Courier New", Courier, monospace;
-  background-color: #666;
-}
-.logfile-inner {
-  overflow-y: scroll;
-  overflow-x: hidden;
-  max-height: calc(60vh);
-  border-bottom: 1px solid black;
-  display: none;
-  cursor: text;
-}
-.iframe-log {
-  width: 100%;
-  height: calc(20vh);
-}
-.iframe-wrap {
-  width: 50%;
-  float: left;
-  box-sizing: border-box;
-}
-.logtab-bar {
-  overflow-y: scroll;
-  max-height: calc(20vh);
-}
-.logtab-btn {
-  margin: 0px;
-  cursor: pointer;
-  border: 2px solid #666;
-  overflow:hidden;
-  text-overflow: ellipsis;
-  width: 12.5%;
-  white-space: nowrap;
-  box-sizing: border-box;
-}
-.logtab-close-btn {
-  background: #cfcece;
-  float: right;
-}
-.logtab-tab-btn {
-  float: left;
-}
-.logtab-btn-selected {
-  border: 2px solid blue;
-  font-weight: bold;
-}
-.logfile-tab {
-  z-index: 11;
-  float: left;
-  cursor: pointer;
-}
-.logfile-shown {
-  display: block;
-}
-.logfile-outer-shown {
-  display: block !important;
-}
-.logtab-shown {
-  display: block;
 }
 
 button:focus {outline:0;}

--- a/conf/report/report.js
+++ b/conf/report/report.js
@@ -1,216 +1,599 @@
-url_tool = ''
-url_tag = ''
-url_test = ''
+/// Custom sorting for DataTable ///////////////////////////////////////
 
-function getUrl() {
-  return location.protocol + '//' + location.host + location.pathname
+(function () {
+
+  function isChapterNumber(a) {
+    var parts = a.split(".")
+
+    for (var i = 0; i < parts.length; i++) {
+
+      if (isNaN(Number(parts[i]))) {
+        return false
+      }
+    }
+
+    return true
+  };
+
+  function chapterNumberCompare(a, b) {
+    if (!isChapterNumber(a)) {
+      if (!isChapterNumber(b)) {
+        return ((a < b) ? -1 : ((a > b) ? 1 : 0))
+      } else {
+        return -1
+      }
+    } else if (!isChapterNumber(b)) {
+      return 1
+    }
+
+    var a_parts = a.split(".")
+    var b_parts = b.split(".")
+
+    /* One or none of these loops will be executed */
+    while (a_parts.length < b_parts.length) {
+      a_parts.push("0")
+    }
+
+    while (a_parts.length > b_parts.length) {
+      b_parts.push("0")
+    }
+
+    for (var i = 0; i < a_parts.length; i++) {
+      if (Number(a_parts[i]) == Number(b_parts[i])) {
+        continue
+      } else if (Number(a_parts[i]) < Number(b_parts[i])) {
+        return -1
+      } else if (Number(a_parts[i]) > Number(b_parts[i])) {
+        return 1
+      }
+    }
+
+    return 0
+  }
+
+  $.fn.dataTable.ext.type.order['sv-id-asc'] = function (a, b) {
+    return chapterNumberCompare(a, b)
+  }
+
+  $.fn.dataTable.ext.type.order['sv-id-desc'] = function (a, b) {
+    return chapterNumberCompare(b, a)
+  }
+
+  $.fn.dataTable.ext.order['test-status'] = function (settings, col) {
+    return this.api().column(col, { order: 'index' }).nodes().map(function (td, i) {
+      p = eval(td.textContent)
+      if (typeof p !== 'undefined') {
+        return 1 - p
+      }
+      return 2
+    })
+  }
+
+}())
+
+/// Utils //////////////////////////////////////////////////////////////
+
+function is_string(o) { return (typeof o === "string" || o instanceof String) }
+function is_empty(str) { return str.length === 0 }
+
+/// ConfigLoader ///////////////////////////////////////////////////////
+
+// Global map where loaded configs put data under their individual keys.
+// The key is: "${tool}/${tag}", where both tool and tag are lowercase.
+// The variable is considered PRIVATE - do not use it outside of ConfigLoader.
+config_loader_data = {}
+
+class ConfigLoader {
+  constructor() {
+    this._data = null
+    this._loaded_key = null
+  }
+
+  // Loads config for specified tool and tag.
+  // NOTE: do not call this concurrently multiple times.
+  async load(tool, tag) {
+    console.assert(is_string(tool) && !is_empty(tool), tool)
+    console.assert(is_string(tag) && !is_empty(tag), tag)
+
+    tool = tool.toLowerCase()
+    tag = tag.toLowerCase()
+
+    const key = `${tool}/${tag}`;
+
+    if (this._loaded_key === key) {
+      return this._data
+    }
+
+    const path = `results/${tool}/${tag}.config.js`
+
+    config_loader_data[key] = undefined
+
+    let script = document.createElement("script")
+    const loading_done = new Promise((resolve, reject) => {
+      script.onload = resolve
+      script.onerror = reject
+    })
+    script.src = path
+    document.head.appendChild(script)
+    try {
+      await loading_done
+    } catch (e) {
+      console.error("Config script loading failed.\n"
+          + "tool: %s\ntag: %s\nkey: %s\npath: %s\nexception: %o", tool, tag, key, path, e)
+      return null
+    }
+    script.remove()
+
+    if (config_loader_data[key] === undefined) {
+      console.error("The loaded config script didn't assign anything to a dedicated global variable. The script probably has been generated incorrectly.\n"
+          + "tool: %s\ntag: %s\nkey: %s\npath: %s", tool, tag, key, path)
+      return null
+    }
+
+    console.debug("Config loaded. key: %s; path: %s", key, path)
+
+    this._loaded_key = key
+    this._data = config_loader_data[key]
+    delete config_loader_data[key]
+
+    return this._data
+  }
+
+  // Releases data. Note that The data still resides in memory if there
+  // are other references to it.
+  unload() {
+    if (this._loaded_key !== null) {
+      const key = this._loaded_key
+      this._data = null;
+      this._loaded_key = null;
+      console.debug("Config unloaded. key: %s", key)
+    }
+  }
+
+  get data() { return this._data }
 }
 
-function updateUrl() {
-  window.history.pushState(null, null, getUrl() + '#' +
-	  [url_tool, url_tag, url_test].join('|'))
-};
+/// ReportViewerState //////////////////////////////////////////////////
 
-function clearUrl() {
-  url_tool = '';
-  url_tag = '';
-  url_test = '';
-  window.history.pushState(null, null, getUrl())
+class ReportViewerState {
+  constructor() {
+    this._state = {
+      current_tool_tag: [null, null],
+      current_test: null,
+    }
+
+    this._subscribers = {}
+    for (const state_key of Object.keys((this._state))) {
+      this._subscribers[state_key] = new Set()
+    }
+  }
+
+  set(new_values, sender=undefined) {
+    const interested_subscribers = new Set()
+    const modified_values = {}
+
+    console.debug("Set state:", new_values)
+    for (const [key, value] of Object.entries(new_values)) {
+      console.assert(key in this._state, key)
+      console.debug(`state change: ${key}: "${this._state[key]}" → "${value}"`)
+      this._state[key] = value
+      modified_values[key] = value
+      this._subscribers[key].forEach(v => interested_subscribers.add(v))
+    }
+    interested_subscribers.forEach(cb => cb(modified_values, sender))
+    console.groupEnd()
+  }
+
+  get(key) {
+    console.assert(key in this._state, key)
+    return this._state[key]
+  }
+
+  subscribe(state_keys, callback) {
+    for (const key of state_keys) {
+      console.assert(key in this._subscribers, key)
+      this._subscribers[key].add(callback)
+    }
+  }
+
+  unsubscribe(state_keys, callback) {
+    for (const key of state_keys) {
+      console.assert(key in this._subscribers, key)
+      this._subscribers[key].remove(callback)
+    }
+  }
 }
 
-function isChapterNumber(a) {
-  var parts = a.split(".");
+/// TestDetailsPanel ///////////////////////////////////////////////////
 
-  for (var i = 0; i < parts.length; i++) {
+class TestDetailsPanel {
+  constructor(state_manager, html_element) {
+    this._state = state_manager
+    this._panel = html_element
 
-  if (isNaN(Number(parts[i]))) {
-     return false;
-   }
- }
+    this._log = this._panel.querySelector(".p_log")
+    this._file = this._panel.querySelector(".p_file")
+    this._tests_list = this._panel.querySelector(".p_tests-list")
+    this._item_template = this._tests_list.querySelector(".p_item-template")
+    this._close_button = this._panel.querySelector(".p_close-button")
 
-  return true;
-};
+    this._config = new ConfigLoader()
 
-function chapterNumberCompare(a, b) {
-  if (!isChapterNumber(a)) {
-    if (!isChapterNumber(b)) {
-      return ((a < b) ? -1 : ((a > b) ? 1 : 0));
+    this._test_name_to_id = new Map()
+    this._items = []
+    this._selected_item = null
+    this._last_viewed_test = null,
+
+    this._state.subscribe(["current_tool_tag", "current_test"], this._state_changed.bind(this))
+
+    this._close_button.onclick = () => this.close()
+  }
+
+  async _state_changed(values, sender) {
+    if (sender === this)
+      return
+
+    if ("current_tool_tag" in values) {
+      const [tool, tag] = values.current_tool_tag
+
+      if (tool !== null && tag !== null) {
+        await this._load_tests(tool, tag)
+        this._show_test(this._state.get("current_test"))
+      } else {
+        this._unload_and_hide()
+      }
+    } else if ("current_test" in values) {
+      this._show_test(values.current_test)
+    }
+  }
+
+  async _load_tests(tool, tag) {
+    console.assert(is_string(tool) && !is_empty(tool), tool)
+    console.assert(is_string(tag) && !is_empty(tag), tag)
+
+    tool = tool.toLowerCase()
+    tag = tag.toLowerCase()
+
+    await this._config.load(tool, tag)
+
+    this._set_selected_item(null)
+    for (const item of this._items)
+      item.remove()
+    this._items = []
+    this._test_name_to_id.clear()
+
+    let test_id = 0
+    for (const [name, status, log_url, first_input_url] of this._config.data) {
+      this._test_name_to_id.set(name, test_id)
+
+      const item = this._item_template.content.firstElementChild.cloneNode(true)
+      if (status)
+        item.classList.add("s_passed")
+      item.querySelector("slot[name='test-name']").replaceWith(name)
+      item._test_id = test_id
+      item.onclick = this._item_clicked.bind(this)
+
+      this._tests_list.appendChild(item)
+      this._items.push(item)
+
+      ++test_id
+    }
+  }
+
+  _show_test(test) {
+    console.assert(this._current_tool !== null)
+    console.assert(test === null || is_string(test), test)
+
+    if (!this._test_name_to_id.has(test)) {
+      if (this._test_name_to_id.has(this._last_viewed_test)) {
+        test = this._last_viewed_test
+        console.debug(`Using last viewed test: "${test}"`)
+      } else {
+        try {
+          // Use first available test name
+          test = this._config.data[0][0]
+          console.debug(`Using first available test: "${test}"`)
+        } catch (e) {
+          console.error("Loaded tests list is empty.\n"
+              + "tool: %s\ntag: %s", this._current_tool, this._current_test)
+          return
+        }
+      }
+      this._state.set({ current_test: test }, this)
+    }
+    const test_id = this._test_name_to_id.get(test)
+    const log_url = this._config.data[test_id][2]
+    const first_input_url = this._config.data[test_id][3]
+    const item = this._items[test_id]
+
+    this._open_log(log_url)
+    this._open_file(first_input_url)
+    this._set_selected_item(item)
+    this._last_viewed_test = test
+
+    this._panel.classList.remove("s_hidden")
+  }
+
+  _open_log(url) {
+    console.assert(is_string(url) && !is_empty(url), url)
+    this._log.contentWindow.location.replace(url);
+  }
+
+  _open_file(url) {
+    console.assert(is_string(url) && !is_empty(url), url)
+    this._file.contentWindow.location.replace(url);
+  }
+
+
+  _set_selected_item(item) {
+    if (this._selected_item === item)
+      return;
+
+    if (this._selected_item)
+      this._selected_item.classList.remove("s_selected")
+    if (item) {
+      item.classList.add("s_selected")
+      this._selected_item = item
     } else {
-      return -1;
-    }
-  } else if (!isChapterNumber(b)) {
-    return 1;
-  }
-
-  var a_parts = a.split(".");
-  var b_parts = b.split(".");
-
-  /* One or none of these loops will be executed */
-  while (a_parts.length < b_parts.length) {
-    a_parts.push("0");
-  }
-
-  while (a_parts.length > b_parts.length) {
-    b_parts.push("0");
-  }
-
-  for (var i = 0; i < a_parts.length; i++) {
-    if (Number(a_parts[i]) == Number(b_parts[i])) {
-      continue;
-    } else if (Number(a_parts[i]) < Number(b_parts[i])) {
-      return -1;
-    } else if (Number(a_parts[i]) > Number(b_parts[i])) {
-      return 1;
+      this._selected_item = null
     }
   }
 
-  return 0;
+  _item_clicked(event) {
+    const test_id = event.target._test_id
+    console.assert(test_id >= 0 || test_id < this._config.data.length, test_id)
+
+    const name = this._config.data[test_id][0]
+    const log_url = this._config.data[test_id][2]
+    const first_input_url = this._config.data[test_id][3]
+
+    this._open_log(log_url)
+    this._open_file(first_input_url)
+    this._set_selected_item(event.target)
+    this._last_viewed_test = name
+    this._state.set({current_test: name})
+  }
+
+  _unload_and_hide() {
+    this._panel.classList.add("s_hidden")
+
+    this._open_log("about:blank")
+    this._open_file("about:blank")
+
+    this._set_selected_item(null)
+    for (const item of this._items) {
+      item.remove()
+    }
+    this._items = []
+    this._test_name_to_id.clear()
+    this._config.unload()
+  }
+
+  close() {
+    this._unload_and_hide()
+    this._state.set({ current_tool_tag: [null, null], current_test: null }, this)
+  }
 }
 
-$.fn.dataTable.ext.type.order['sv-id-asc'] = function (a, b) {
-  return chapterNumberCompare(a, b);
-};
+/// TestResultCellsSelectionController /////////////////////////////////
 
-$.fn.dataTable.ext.type.order['sv-id-desc'] = function (a, b) {
-  return chapterNumberCompare(b, a);
-};
+class TestResultCellsSelectionController {
+  constructor(state_manager, tables) {
+    this._state = state_manager
+    this._tables = tables
 
-$.fn.dataTable.ext.order['test-status'] = function ( settings, col ) {
-  return this.api().column( col, {order:'index'} ).nodes().map( function ( td, i ) {
-    p = eval(td.textContent)
-    if (typeof p !== 'undefined') {
-      return 1 - p;
-    }
-    return 2;
-  });
-};
+    this._selected_cell = null;
 
-function toggleLog(tool, tag, test, cell) {
-  all_logs = document.getElementsByClassName("logfile-shown");
+    this._state.subscribe(["current_tool_tag"], this._state_changed.bind(this))
 
-  var div_id = [tool, tag, "logfile"].join("-");
-
-  for (var i=0; i < all_logs.length; ++i) {
-    if (all_logs[i].id != div_id) {
-      hideLog(all_logs[i].id);
+    for (const table of this._tables) {
+      const cells = table.querySelectorAll("tbody > tr > td:not(:empty)")
+      for (const cell of cells) {
+        cell.onclick = this._cell_clicked.bind(this)
+      }
     }
   }
 
-  log_div = document.getElementById(div_id);
-  outer_div = document.getElementById('logfile-outer');
+  _state_changed(values, sender) {
+    if (sender === this)
+      return
 
-  if (log_div.classList.toggle("logfile-shown")) {
-    outer_div.classList.add("logfile-outer-shown");
-  } else {
-    outer_div.classList.remove("logfile-outer-shown");
-    clearUrl();
-    test = null;
+    if ("current_tool_tag" in values) {
+      const [tool, tag] = values.current_tool_tag
+      this._set_selected_cell(tool, tag)
+    }
   }
 
-  if (test === null) {
-    window.open('about:blank', 'log-frame')
-  } else {
-    url_tool = tool;
-    if (url_tag === tag){
-      test = url_test;
+  _set_selected_cell(tool, tag) {
+    if (tool === null || tag === null) {
+      this._set_selected_cell_element(null)
+      return
+    }
+
+    tool = tool.toLowerCase()
+    tag = tag.toLowerCase()
+
+    let cell = null
+    for (const table of this._tables) {
+      cell = table.querySelector(`tbody > tr[data-tag="${tag}"] > td[data-tool="${tool}"]`);
+      if (cell)
+        break;
+    }
+    this._set_selected_cell_element(cell ? cell : null)
+  }
+
+  _set_selected_cell_element(element) {
+    if (element === this._selected_cell)
+      return;
+
+    if (this._selected_cell)
+      this._selected_cell.classList.remove("s_selected")
+    if (element) {
+      console.debug(`Selecting cell: %o`, element)
+      element.classList.add("s_selected")
+      this._selected_cell = element
     } else {
-      url_tag = tag;
-      url_test = test;
-    };
-    var test_btn = document.getElementById(
-      ['logtab', 'btn', tool, tag, test].join('-'));
-    test_btn.onclick();
+      console.debug(`Selecting cell: null`)
+      this._selected_cell = null
+    }
   }
 
-  var selected_cell = document.querySelector(".test-cell-selected");
-  if (!cell) {
-    if (selected_cell) {
-      selected_cell.classList.remove("test-cell-selected");
-    }
-  } else {
-    if (cell != selected_cell) {
-      cell.classList.add("test-cell-selected");
+  _cell_clicked(event) {
+    const tool = event.target.dataset.tool
+    const tag = event.target.parentElement.dataset.tag
+
+    const [current_tool, current_tag] = this._state.get("current_tool_tag")
+
+    if (tool === current_tool && tag === current_tag) {
+      this._set_selected_cell_element(null)
+      this._state.set({ current_tool_tag: [null, null], current_test: null }, this)
     } else {
-      cell.classList.remove("test-cell-selected");
+      this._set_selected_cell_element(event.target)
+      this._state.set({ current_tool_tag: [tool, tag], current_test: null }, this)
+    }
+  }
+}
+
+/// KeyboardControl ////////////////////////////////////////////////////
+
+class KeyboardControl {
+  constructor(state_manager) {
+    this._state = state_manager
+
+    document.addEventListener("keydown", this._key_pressed.bind(this))
+  }
+
+  _key_pressed(event) {
+    switch (event.key) {
+      case "Escape":
+      case "Esc":
+        const current_test = this._state.get("current_test")
+        this._state.set({ current_tool_tag: [null, null], current_test: null })
+        break
+    }
+  }
+}
+
+/// UrlParametersController ////////////////////////////////////////////
+
+class UrlParametersController {
+  constructor(state_manager) {
+    this._state = state_manager
+    this._state.subscribe(["current_tool_tag", "current_test"], this._state_changed.bind(this))
+    this._state_handling_suspended = false
+    this._update_state_from_parameters()
+    window.addEventListener("popstate", this._restore_state.bind(this))
+  }
+
+  _state_changed(values, sender) {
+    if (this._state_handling_suspended)
+      return
+
+    const url = new URL(window.location)
+    url.hash = ""
+
+    if ("current_test" in values || "current_tool_tag" in values) {
+      const [tool, tag] = this._state.get("current_tool_tag")
+      const test = this._state.get("current_test")
+      if (tool === null || tag === null) {
+        url.searchParams.delete("v")
+        document.title = `SystemVerilog Report`
+      } else if (test !== null) { // Do not show "temporary" URLs without a test
+        url.searchParams.set("v", `${tool} ${tag} ${test}`)
+        document.title = `${tool}/${tag}/${test} - SystemVerilog Report`
+      } else {
+        return
+      }
+      if (url.href == window.location.href)
+        return
+      if (sender === this)
+        history.replaceState(null, "", url.href)
+      else
+        history.pushState(null, "", url.href)
     }
   }
 
-  logs = document.getElementById("logfile-outer");
+  _restore_state(event) {
+    this._state_handling_suspended = true
+    this._update_state_from_parameters()
+    this._state_handling_suspended = false
+  }
 
-  scroll = document.documentElement.scrollTop;
-  document.body.style.paddingBottom = logs.offsetHeight + "px";
-  document.documentElement.scrollTop = scroll;
+  _update_state_from_parameters() {
+    let url = new URL(window.location)
+
+    const set_state_if_valid = (tool, tag, test) => {
+      if (tool !== undefined && tool !== ""
+          && tag !== undefined && tag !== ""
+          && test !== undefined && tag !== "") {
+        this._state.set({ "current_tool_tag": [tool, tag], "current_test": test })
+        return true
+      }
+      return false
+    }
+
+    // Try URL parameter "v" containing "${TOOL} ${TAG} ${TEST}"
+    const v = url.searchParams.get("v")
+    if (is_string(v) && !is_empty(v)) {
+      const [tool, tag, test] = v.split(" ")
+      if (set_state_if_valid(tool, tag, test))
+        return
+    }
+
+    // Try URL hash containing "#${TOOL}|${TAG}|${TEST}" (legacy format)
+    if (is_string(url.hash) && !is_empty(url.hash)) {
+      const hash = decodeURIComponent(url.hash).substr(1)
+      const [tool, tag, test] = hash.split("|")
+      if (set_state_if_valid(tool, tag, test))
+        return
+    }
+
+    // Set initial state (no selected test). Required for correct state
+    // restoration from history.
+    this._state.set({ "current_tool_tag": [null, null], "current_test": null })
+  }
 }
 
-function testResultClicked(event) {
-  var tool = event.target.dataset.tool;
-  var tag = event.target.parentElement.dataset.tag;
-  var test = event.target.dataset.headTest;
-  toggleLog(tool, tag, test, event.target);
-}
+/// Main ///////////////////////////////////////////////////////////////
 
-// Install events after DOM is loaded
-window.addEventListener('DOMContentLoaded', (event) => {
-  var test_result_cells = document.querySelectorAll(".dataTable > tbody > tr > td:not(.test-na)");
-  test_result_cells.forEach((target) => {
-    target.addEventListener('click', testResultClicked, false);
+const state_manager = new ReportViewerState()
+
+var test_details_panel = null;
+var cells_selection_controller = null;
+var keyboard_control = null;
+var url_parameters_controller = null;
+
+window.addEventListener('DOMContentLoaded', function(event) {
+  const test_details_panel_element = document.querySelector(
+      ".c_test-details-panel")
+  test_details_panel = new TestDetailsPanel(state_manager, test_details_panel_element)
+
+  const tables = document.querySelectorAll(".dataTable")
+  cells_selection_controller = new TestResultCellsSelectionController(state_manager, tables)
+
+  keyboard_control = new KeyboardControl(state_manager)
+  url_parameters_controller = new UrlParametersController(state_manager)
+
+  // Track panel height and store it in body's "--panel-height" CSS property
+  // TODO: move to a class, probably to TestDetailsPanel.
+  const panel_resize_observer = new ResizeObserver(entries => {
+    console.assert(entries.length === 1, entries)
+    const panel_entry = entries[0]
+    document.body.style.setProperty("--panel-height", `${panel_entry.borderBoxSize[0].blockSize}px`)
+  })
+  state_manager.subscribe(["current_tool_tag"], (values) => {
+    if (values.current_tool_tag[0] !== null) {
+      panel_resize_observer.observe(test_details_panel_element, { box: "border-box" })
+    } else {
+      panel_resize_observer.unobserve(test_details_panel_element)
+      document.body.style.removeProperty("--panel-height")
+    }
+  })
+  if (state_manager.get("current_tool_tag")[0] !== null)
+    panel_resize_observer.observe(test_details_panel_element, { box: "border-box" })
+
+  // Install tooltip component
+  $(function() {
+    $(document).tooltip({ track: true, show: 0, hide: 0 });
   });
-});
-
-function hideLog(div_id) {
-  log_div = document.getElementById(div_id);
-  log_div.classList.remove("logfile-shown");
-
-  cells = document.getElementsByClassName("test-cell-selected");
-  for (var i=0; i < cells.length; ++i) {
-    cells[i].classList.remove("test-cell-selected");
-  }
-}
-
-function selectTab(path, btn_id, file, test_name) {
-  url_test = test_name;
-  updateUrl();
-  all_btns = document.getElementsByClassName("logtab-btn-selected");
-  for (var i=0; i < all_btns.length; i++) {
-    all_btns[i].classList.remove("logtab-btn-selected");
-  }
-
-  btn = document.getElementById(btn_id);
-  btn.classList.add("logtab-btn-selected");
-
-  window.open(path, "log-frame");
-
-  if (file === null) {
-    window.open("about:blank", 'file-frame')
-  } else {
-    window.open(file, 'file-frame')
-  }
-}
-
-$(function() {
-  $(document).tooltip({
-    track: true,
-    show: 0,
-    hide: 0
-  });
-});
-
-$(document).ready(function() {
-  var hash = decodeURIComponent(location.hash).substr(1).split('|');
-
-  var tool = hash[0];
-  var tag = hash[1];
-  var test = hash[2];
-
-  var test_cell = document.querySelector(
-    `.dataTable > tbody > tr[data-tag="${tag}"] > td[data-tool="${tool}"]`);
-  if (!test_cell)
-    return;
-
-  var test_btn = document.getElementById(
-    ['logtab', 'btn', tool, tag, test].join('-'));
-
-  test_cell.click();
-  if (test_btn !== null)
-    test_btn.click();
-});
+})

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -28,6 +28,7 @@ import urllib.parse
 import dataclasses
 import enum
 from typing import Dict, Any, List, Set, Iterable
+import json
 
 parser = argparse.ArgumentParser()
 
@@ -428,6 +429,31 @@ def renderInputFileToHTMLFile(
                 csspath=csspath, filename=input_file_path, code=code))
 
 
+def renderTagResultsConfig(
+        js_path: str, tool: str, tag: str, test_results: Iterable[TestResult]):
+    tool = tool.lower()
+    tag = tag.lower()
+    js_global_variable_name = f"config_loader_data['{tool}/{tag}']"
+
+    # Order of values in each entry:
+    # [name, status, log_html_path, first_input_file_html_path]
+    config = []
+    for test_result in test_results:
+        name = test_result.name
+        status = int(test_result.status == TestStatus.PASSED)
+        log_html_file = test_result.log_html_file
+        first_input_html = test_result.input_files[0] + ".html"
+        first_input_html = urllib.parse.quote(first_input_html)
+        config.append([name, status, log_html_file, first_input_html])
+
+    js_data = json.dumps(config, separators=(",", ":"))
+    code = f"{js_global_variable_name} = {js_data}"
+
+    os.makedirs(os.path.dirname(js_path), exist_ok=True)
+    with open(js_path, "w") as f:
+        f.write(code)
+
+
 def collect_logs(runner_name: str):
     tool_results = ToolResults()
 
@@ -435,6 +461,8 @@ def collect_logs(runner_name: str):
     # with size > minimum_throughput_file_size
     passed_tests_time = 0.0
     passed_tests_input_files_size = 0.0
+
+    rendered_count = 0
 
     @dataclasses.dataclass
     class TagStatuses:
@@ -571,6 +599,7 @@ def collect_logs(runner_name: str):
         # Render the log if needed
         if not exists_and_is_newer_than(
                 log_html, [log_file, args.log_template, __file__]):
+            rendered_count += 1
             renderLogToHTMLFile(
                 out_dir, log_html, test_result, test_log_data, log_content)
 
@@ -602,6 +631,13 @@ def collect_logs(runner_name: str):
             [t for t in tool_results.tests.values() if tag in t.tags],
             key=TestResultComp)
 
+        config_js = os.path.join(
+            out_dir, "results", runner_name.lower(),
+            f"{tag.lower()}.config.js")
+
+        # Render the config
+        renderTagResultsConfig(config_js, runner_name, tag, tag_results.tests)
+
     try:
         with open(os.path.join(args.logs, runner_name, "version")) as f:
             tool_results.version = f.read().strip()
@@ -619,6 +655,10 @@ def collect_logs(runner_name: str):
     else:
         tool_results.passed_throughput = (
             passed_tests_input_files_size / passed_tests_time / 1024)
+
+    logger.info(
+        f"{runner_name}: (Re)generated {rendered_count}/{tool_results.total_tests} rendered log files."
+    )
 
     return tool_results
 
@@ -651,12 +691,18 @@ for tool_name, tool_results in zip(runner_names, results):
         all_input_files.update(test_result.input_files)
 
 # Render input files
+rendered_count = 0
 for input_file in all_input_files:
     input_file_html = os.path.join(out_dir, input_file + ".html")
     if exists_and_is_newer_than(input_file_html,
                                 [input_file, args.code_template, __file__]):
         continue
+    rendered_count += 1
     renderInputFileToHTMLFile(out_dir, input_file_html, input_file)
+
+logger.info(
+    f"(Re)generated {rendered_count}/{len(all_input_files)} rendered input files."
+)
 
 # CamelCase or undscore_separator csv headers ?
 # We use CamelCase so that gnuplot getting header from CSV displays them

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -23,6 +23,11 @@ import datetime
 import sys
 import os
 import re
+import html
+import urllib.parse
+import dataclasses
+import enum
+from typing import Dict, Any, List, Set, Iterable
 
 parser = argparse.ArgumentParser()
 
@@ -102,116 +107,55 @@ elif args.verbose:
 else:
     logger.setLevel(logging.INFO)
 
-tag_usage = {}
+out_dir = os.path.dirname(os.path.abspath(args.out))
+top_dir = os.path.abspath(os.curdir)
 
 lex = lexers.get_lexer_by_name("systemverilog")
 
-# Initialize templates
-with open(args.code_template, "r") as templ:
-    src_template = jinja2.Template(
-        templ.read(), trim_blocks=True, lstrip_blocks=True)
 
-with open(args.log_template, "r") as templ:
-    log_template = jinja2.Template(
-        templ.read(), trim_blocks=True, lstrip_blocks=True)
+def escapeXmlAttribute(value: str):
+    return str(markupsafe.escape(value)).replace("\n", "&#10;")
 
 
-def exists_and_is_newer_than(b, a):
-    return os.path.exists(a) and os.path.exists(
-        b) and os.path.getctime(b) > os.path.getctime(a)
+def escapeJsString(value: str):
+    def esc(match: re.Match):
+        return rf"\x{ord(match.group(0)):02x}"
+
+    return re.sub(r"[\x00-\x1F\x7F'\"]", esc, value)
 
 
-def formatSrc(ifile, ofile):
-    if exists_and_is_newer_than(ofile, ifile):
-        return
-
-    formatter = HtmlFormatter(
-        full=False, linenos=True, anchorlinenos=True, lineanchors='l')
-
-    os.makedirs(os.path.dirname(ofile), exist_ok=True)
-
-    with open(ofile, 'w') as out:
-        try:
-            f = open(ifile, 'rb')
-        except IOError:
-            out.write('Error when opening file ' + ifile)
-            return
-
-        raw_code = f.read()
-
-        code = highlight(raw_code, lex, formatter)
-
-        filename = os.path.relpath(ifile)
-        src_rel = "../" * filename.count('/')
-        csspath = os.path.join(src_rel, "code.css")
-
-        out.write(
-            src_template.render(csspath=csspath, filename=filename, code=code))
+def surroundWithQuotes(value: str, quot='"'):
+    return quot + str(value) + quot
 
 
-def fileRefToLink(src_rel, fname, link_pat, link_sub_pat, log):
-    f_rel = os.path.relpath(fname)
-    f_html = (
-        '<a href="{0}{1}.html" target="file-frame">{1}</a>'.format(
-            src_rel, f_rel))
-    log = re.sub(
-        link_pat.format(fname), link_sub_pat.format(src_rel, f_rel), log)
-    log = re.sub(fname, f_html, log)
-    formatSrc(fname, os.path.join(os.path.dirname(args.out), f_rel + '.html'))
-    return (f_html, log)
+# Initialize Jinja2 environment with custom filter
+
+jinja2env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
+jinja2env.filters["escape_attr"] = escapeXmlAttribute
+jinja2env.filters["escape_js_str"] = escapeJsString
+jinja2env.filters["quote"] = surroundWithQuotes
 
 
-def totalSize(tags):
-    files = tags['files'].split()
+def exists_and_is_newer_than(target: str, sources: List[str]):
+    if not os.path.exists(target):
+        return False
+
+    for s in sources:
+        if (not os.path.exists(s)
+                or os.path.getctime(s) > os.path.getctime(target)):
+            return False
+
+    return True
+
+
+def totalSize(files):
     size = 0
     for f in files:
-        if (os.path.exists(f)):
+        try:
             size += os.path.getsize(f)
+        except FileNotFoundError:
+            pass
     return size
-
-
-def logToHTML(path_in, path_out, tags, log_content):
-    depth = path_in.count('/') - 1
-    src_relative = '../' * depth
-    files = tags['files'].split()
-    log = str(markupsafe.escape(log_content))
-    log_files_pat = r'({}\S+):\d+'
-    html_pat_ln = r'{}:(\d+)'
-    html_sub_ln = r'<a href="{0}{1}.html#l-\1" target="file-frame">{1}:\1</a>'
-
-    tags['tool'] = "toolname"
-    tags['tool_url'] = "toolname.pl"
-
-    tags['file_urls'] = []
-
-    log_files = re.findall(log_files_pat.format(os.getcwd()), log)
-
-    log_files = list(set(log_files) - set(files))
-
-    for f in log_files:
-        if os.path.isfile(f):
-            _, log = fileRefToLink(
-                src_relative, f, html_pat_ln, html_sub_ln, log)
-
-    for f in files:
-        url, log = fileRefToLink(
-            src_relative, f, html_pat_ln, html_sub_ln, log)
-        tags['file_urls'].append(url)
-
-    tags['file_urls'] = " ".join(tags['file_urls'])
-    tags['log_urls'] = log
-
-    with open(path_out + ".html", 'w') as html:
-        html.write(log_template.render(**tags))
-
-    return os.path.relpath(files[0]) + '.html'
-
-
-def getRelativePaths(paths):
-    paths = paths.split(' ')
-    paths = list(map(lambda x: os.path.realpath(x), paths))
-
-    return ' '.join(paths)
 
 
 def criticalError(msg):
@@ -220,7 +164,7 @@ def criticalError(msg):
 
 
 # class used for sorting "test tabs" in the report
-class TestTupleComp(object):
+class TestResultComp(object):
     def __init__(self, item):
         self.item = item
 
@@ -232,8 +176,8 @@ class TestTupleComp(object):
         return s
 
     def __lt__(self, other):
-        s = self.prepend_nums(self.item[1]["name"])
-        o = self.prepend_nums(other.item[1]["name"])
+        s = self.prepend_nums(self.item.name)
+        o = self.prepend_nums(other.item.name)
 
         return s < o
 
@@ -272,177 +216,418 @@ meta_tags, meta_urls = readConfig(args.meta_tags)
 
 urls = {**urls, **meta_urls}
 
-logger.info("Generating {} from log files in '{}'".format(args.out, args.logs))
 
-data = {}
+@enum.unique
+class TestStatus(enum.Enum):
+    NA = "test-na"
+    PASSED = "test-passed"
+    FAILED = "test-failed"
+    VARIED = "test-varied"
 
-for tag in database:
-    tag_usage[tag] = False
+    def __str__(self):
+        return self.value
 
 
-def collect_logs(runner_name):
-    runner_data = {}
-    runner_tag_usage = {}
+@dataclasses.dataclass
+class TestResult:
+    log_html_file: str = ""
 
-    for tag in database:
-        runner_tag_usage[tag] = False
+    name: str = ""
+    tags: Set[str] = dataclasses.field(default_factory=set)
+    types: Set[str] = dataclasses.field(default_factory=set)
+    input_files: List[str] = dataclasses.field(default_factory=list)
+    # Unit: bytes
+    total_input_files_size: int = 0
+    status: TestStatus = TestStatus.NA
+    exit_code: int = 0
 
-    # all tests info
-    runner_data["tests"] = {}
-    tests = runner_data["tests"]
-    runner_data["date_completed"] = ''
-    runner_data["time_elapsed"] = 0
-    runner_data["user_time"] = 0
-    runner_data["system_time"] = 0
-    runner_data["ram_usage"] = 0
-    runner_data["passed_time"] = 0
-    runner_data["passed_size"] = 0
+    # Unit: seconds
+    timeout: int = 0
 
-    for t in glob(os.path.join(args.logs, runner_name, "**/*.log"),
-                  recursive=True):
-        t_id = t[len(args.logs) + 1:]
+    # Unit: seconds
+    total_time: float = 0
+    user_time: float = 0
+    system_time: float = 0
+
+    # Unit: KB
+    ram_usage: float = 0
+
+
+@dataclasses.dataclass
+class TagResults:
+    status: TestStatus = TestStatus.NA
+    types: List[str] = dataclasses.field(default_factory=list)
+    passed_tests: int = 0
+    tests: List[TestResult] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class ToolResults:
+    tests: Dict[str, TestResult] = dataclasses.field(default_factory=dict)
+    tags: Dict[str, TagResults] = dataclasses.field(default_factory=dict)
+
+    # Unit: seconds
+    total_time: float = 0
+    user_time: float = 0
+    system_time: float = 0
+
+    # Unit: MB
+    max_ram_usage: float = 0
+
+    # Unit: KiB/s
+    passed_throughput: float = 0
+
+    # Tool name. This should be used only for display purposes. Always use
+    # a key from `tools` in `ReportResults` as a runner/tool ID.
+    name: str = ""
+    version: str = ""
+    url: str = ""
+
+    total_passed_tests: int = 0
+    total_passed_tags: int = 0
+    total_tested_tags: int = 0
+
+    @property
+    def total_tests(self):
+        return len(self.tests)
+
+
+@dataclasses.dataclass
+class TagInfo:
+    description: str = ""
+    url: str = ""
+
+
+@dataclasses.dataclass
+class ReportResults:
+    # Results from each runner/tool.
+    # Keys are runner names (i.e. runner class names)
+    tools: Dict[str, ToolResults] = dataclasses.field(default_factory=dict)
+    # Tags used in the report. Keys are tag IDs.
+    tags: Dict[str, TagInfo] = dataclasses.field(default_factory=dict)
+
+
+# Data passed to report template
+report_data = ReportResults()
+
+# Regexp for matching file paths with optional line and column number
+# separated with ":".
+# The patch must contain at least one "/". Designed for finding references to
+# input files in tools' output.
+# Captures 3 groups:
+#   1: file path
+#   2: matched text following file path (i.e. ":row:column")
+#   3: row number
+# Example inputs:
+#   /some/file.sv
+#   relative/file/name.v:12       <- group(2): ":12",    group(3): "12"
+#   /some/file.svh:12:35          <- group(2): ":12:35", group(3): "12"
+PATH_WITH_LINE_NO_MATCHER = re.compile(
+    r"([^\s:\"'`/]*/[^\s:\"'`]+\.\w+)(:(\d+)(?::\d+)?)?")
+
+
+def convertPathsToRelativeLinks(text: str, relative_to: str):
+    """Replaces paths to existing files in "text" with HTML links to them.
+
+    The matched paths can optionally contain row and column number separated
+    with ":". The generated links are relative to "relative_to" and their
+    target (frame in which they open) is "file-frame".
+
+    Designed for finding references to input files in tools' output.
+
+    Args:
+      text: Escaped (for use in HTML) text.
+      relative_to: Directory to which the generated urls will be relative.
+
+    Returns:
+      Text in which paths are replaced with HTML links.
+    """
+    def convertPath(match: re.Match):
+        path: str = html.unescape(match.group(1))
+        if not os.path.exists(path):
+            return match.group(0)
+
+        if path.startswith(top_dir):
+            path = path[len(top_dir) + 1:]
+        elif path.startswith("/"):
+            return match.group(0)
+
+        url = os.path.join(out_dir, path + ".html")
+        url = os.path.relpath(url, relative_to)
+        url = urllib.parse.quote(url)
+        esc_match = str(markupsafe.escape(path))
+        line_no = match.group(3)
+        if line_no is not None:
+            url = f"{url}#l-{line_no}"
+            esc_match = esc_match + (match.group(2) or "")
+        return f'<a href="{url}" target="file-frame">{esc_match}</a>'
+
+    return PATH_WITH_LINE_NO_MATCHER.sub(convertPath, text)
+
+
+with open(args.log_template, "r") as templ:
+    log_template = jinja2env.from_string(templ.read())
+
+
+def renderLogToHTMLFile(
+        out_dir: str, log_html_path: str, test_result: TestResult,
+        test_log: Dict[str, str], log_content: str):
+    files_map: Dict[str, str] = {}
+    log_html_dir = os.path.dirname(log_html_path)
+    for input_file in test_result.input_files:
+        # Absolute path:
+        input_file_html = os.path.join(out_dir, input_file + ".html")
+        # Path relative to rendered log:
+        input_file_html = os.path.relpath(input_file_html, log_html_dir)
+
+        files_map[input_file] = urllib.parse.quote(input_file_html)
+
+    log_content = convertPathsToRelativeLinks(
+        str(markupsafe.escape(log_content)), log_html_dir)
+
+    os.makedirs(os.path.dirname(log_html_path), exist_ok=True)
+    with open(log_html_path, 'w') as f:
+        f.write(
+            log_template.render(
+                input_files_map=files_map,
+                result=test_result,
+                log=test_log,
+                content=log_content))
+
+
+with open(args.code_template, "r") as templ:
+    src_template = jinja2env.from_string(templ.read())
+
+
+def renderInputFileToHTMLFile(
+        out_dir: str, html_path: str, input_file_path: str):
+    formatter = HtmlFormatter(
+        full=False, linenos=True, anchorlinenos=True, lineanchors='l')
+
+    os.makedirs(os.path.dirname(html_path), exist_ok=True)
+
+    raw_code = ""
+    try:
+        with open(input_file_path, 'rb') as f:
+            raw_code = f.read()
+    except IOError:
+        logger.warning(f"Error when opening file {input_file_path}")
+        try:
+            with open(html_path, 'w') as out:
+                out.write('Error when opening file ' + input_file_path)
+        except IOError:
+            pass
+        return
+
+    code = highlight(raw_code, lex, formatter)
+    csspath = os.path.join(out_dir, "code.css")
+    csspath = os.path.relpath(csspath, os.path.dirname(html_path))
+    with open(html_path, 'w') as out:
+        out.write(
+            src_template.render(
+                csspath=csspath, filename=input_file_path, code=code))
+
+
+def collect_logs(runner_name: str):
+    tool_results = ToolResults()
+
+    # Values used to calculate throughput. Totals are collected only for files
+    # with size > minimum_throughput_file_size
+    passed_tests_time = 0.0
+    passed_tests_input_files_size = 0.0
+
+    @dataclasses.dataclass
+    class TagStatuses:
+        passed_count: int = 0
+        present_statuses: Set[TestStatus] = dataclasses.field(
+            default_factory=set)
+        present_types: Set[str] = dataclasses.field(default_factory=set)
+
+    tags_statuses: Dict[str, TagStatuses] = {}
+
+    for log_file in glob(os.path.join(args.logs, runner_name, "**/*.log"),
+                         recursive=True):
+        # Strip f"{args.logs}/" prefix from log file path
+        t_id = log_file[len(args.logs) + 1:]
         logger.debug("Found log: " + t_id)
 
         # Tests that have not run will have an existing, but empty logfile.
-        if os.path.getsize(t) == 0:
+        if os.path.getsize(log_file) == 0:
             continue
 
-        tests[t_id] = {}
+        test_result = TestResult()
 
-        test_tags = [
+        remaining_parameters = {
             "name", "tags", "should_fail", "rc", "date_completed",
             "description", "files", "incdirs", "top_module", "runner",
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
             "should_fail_because", "defines", "compatible-runners"
-        ]
-        with open(t, "r") as f:
+        }
+        test_log_data: Dict[str, Any] = {}
+        log_content = ""
+
+        with open(log_file, "r") as f:
             try:
                 for l in f:
-                    tag = re.search(r"^([a-zA-Z_-]+):(.+)", l)
+                    attr = re.search(r"^([a-zA-Z_-]+):(.+)", l)
 
-                    if tag is None:
+                    if attr is None:
                         raise KeyError(
-                            "Could not find tags: {}".format(
-                                ", ".join(test_tags)))
+                            "Could not find parameters: {}".format(
+                                ", ".join(remaining_parameters)))
 
-                    param = tag.group(1).lower()
-                    value = tag.group(2).strip()
+                    param = attr.group(1).lower()
+                    value = attr.group(2).strip()
 
-                    if param in test_tags:
-                        test_tags.remove(param)
-
-                        # append all meta-tags
-                        if param in "tags":
-                            for mk in meta_tags:
-                                mv = meta_tags[mk].split()
-                                if any(x in mv for x in value.split()):
-                                    value += " " + mk
-
-                        tests[t_id][param] = value
-
-                        if len(test_tags) == 0:
-                            # found all tags
-                            break
-                    else:
+                    if param not in remaining_parameters:
                         logger.warning(
                             "Skipping unknown parameter: {} in {}".format(
-                                param, t))
+                                param, log_file))
+                        continue
+                    if param in test_log_data:
+                        logger.warning(
+                            "Skipping duplicated parameter: {} in {}".format(
+                                param, log_file))
+                        continue
+
+                    test_log_data[param] = value
+
+                    remaining_parameters.remove(param)
+                    if len(remaining_parameters) == 0:
+                        # found all tags
+                        break
 
             except Exception as e:
                 logger.warning(
-                    "Skipping {} on {}: {}".format(t, runner_name, str(e)))
-                del tests[t_id]
+                    "Skipping {} on {}: {}".format(
+                        log_file, runner_name, str(e)))
                 continue
 
             log_content = f.read()
-            tests[t_id]["fname"] = os.path.join('logs', t_id + '.html')
-            tests[t_id]["input_size"] = totalSize(tests[t_id])
 
-            tool_should_fail = tests[t_id]["should_fail"] == "1"
-            tool_rc = int(tests[t_id]["rc"])
-            tool_crashed = tool_rc >= 126
-            tool_failed = tests[t_id]["tool_success"] == "0"
-            if tool_crashed or tool_should_fail != tool_failed:
-                tests[t_id]["status"] = "test-failed"
-            elif tests[t_id]["mode"] == 'simulation' and not parseLog(
-                    log_content):
-                tests[t_id]["status"] = "test-failed"
-            else:
-                tests[t_id]["status"] = "test-passed"
+        tool_results.tests[t_id] = test_result
 
-            t_html = t.replace(
-                args.logs, os.path.join(os.path.dirname(args.out), "logs"))
-            os.makedirs(os.path.dirname(t_html), exist_ok=True)
+        if tool_results.name == "":
+            tool_results.name = test_log_data["runner"]
 
-            tests[t_id]["first_file"] = logToHTML(
-                t, t_html, tests[t_id], log_content)
+        test_result.name = test_log_data["name"]
 
-            if tests[t_id]["status"] == "test-passed":
-                test_file_size = float(tests[t_id]["input_size"])
-                if test_file_size > minimum_throughput_file_size:
-                    runner_data["passed_time"] += float(
-                        tests[t_id]["time_elapsed"])
-                    runner_data["passed_size"] += test_file_size
+        # Convert splitted "tags" to set() and append all meta-tags
+        test_result.tags = set(test_log_data["tags"].split())
+        for meta_tag, dependency_tags in meta_tags.items():
+            dependency_tags = set(dependency_tags.split())
+            if not dependency_tags.isdisjoint(test_result.tags):
+                test_result.tags.add(meta_tag)
 
-            runner_data["time_elapsed"] += float(tests[t_id]["time_elapsed"])
-            runner_data["user_time"] += float(tests[t_id]["user_time"])
-            runner_data["system_time"] += float(tests[t_id]["system_time"])
-            current_ram_usage = float(tests[t_id]["ram_usage"]) / 1000
-            if runner_data["ram_usage"] < current_ram_usage:
-                runner_data["ram_usage"] = current_ram_usage
+        test_result.input_files = [
+            os.path.relpath(f, top_dir)
+            for f in test_log_data["files"].split()
+        ]
 
-        # check if test was skipped
-        if t_id not in tests:
-            continue
+        test_result.types = test_log_data["type"].split()
+        test_result.total_input_files_size = totalSize(test_result.input_files)
+        test_result.exit_code = int(test_log_data["rc"])
 
-        # Initialize the tag-based side of the result dict
-        runner_data["tags"] = {}
-        tags = runner_data["tags"]
+        # Determine test status
+        tool_should_fail = test_log_data["should_fail"] == "1"
+        tool_crashed = test_result.exit_code >= 126
+        tool_failed = test_log_data["tool_success"] == "0"
 
-        for tag in database:
-            tags[tag] = {}
-            tags[tag]["status"] = []
-            tags[tag]["type"] = []
+        if tool_crashed or tool_should_fail != tool_failed:
+            test_result.status = TestStatus.FAILED
+        elif test_log_data["mode"] == "simulation" and not parseLog(
+                log_content):
+            test_result.status = TestStatus.FAILED
+        else:
+            test_result.status = TestStatus.PASSED
+            tool_results.total_passed_tests += 1
+            # Collect stats for calculating passed_throughput
+            input_files_size = test_result.total_input_files_size
+            if input_files_size > minimum_throughput_file_size:
+                passed_tests_input_files_size += input_files_size
+                passed_tests_time += float(test_log_data["time_elapsed"])
 
-        # generate tags summary
-        for _, test in tests.items():
-            for tag in test["tags"].split(" "):
-                try:
-                    runner_tag_usage[tag] = True
-                    tags[tag]["status"].append(test["status"])
-                    for type in test["type"].split(" "):
-                        if type not in tags[tag]["type"]:
-                            tags[tag]["type"].append(type)
-                except KeyError:
-                    logger.warning("Tag not present in the database: " + tag)
-                    database[tag] = ''
-                    runner_tag_usage[tag] = True
-                    tags[tag] = {}
-                    tags[tag]["status"] = test["status"]
-                    tags[tag]["type"] = test["type"]
-                    continue
+        test_result.timeout = int(test_log_data["timeout"])
 
-        for tag in tags:
-            passed_count = tags[tag]["status"].count("test-passed")
-            tags[tag]["passed-num"] = passed_count
+        test_result.total_time = float(test_log_data["time_elapsed"])
+        test_result.user_time = float(test_log_data["user_time"])
+        test_result.system_time = float(test_log_data["system_time"])
 
-            if len(tags[tag]["status"]) == 0:
-                tags[tag]["status"] = "test-na"
-            elif all(tags[tag]["status"][0] == x for x in tags[tag]["status"]):
-                tags[tag]["status"] = tags[tag]["status"][0]
-            else:
-                tags[tag]["status"] = "test-varied"
+        tool_results.total_time += test_result.total_time
+        tool_results.user_time += test_result.user_time
+        tool_results.system_time += test_result.system_time
 
-    if runner_data["passed_time"] == 0:
-        runner_data["passed_throughput"] = 0
+        test_result.ram_usage = float(test_log_data["ram_usage"])  # KB
+        ram_usage_mb = test_result.ram_usage / 1000
+        if tool_results.max_ram_usage < ram_usage_mb:
+            tool_results.max_ram_usage = ram_usage_mb
+
+        logs_out_dir = os.path.join(out_dir, "logs")
+        log_html = os.path.join(logs_out_dir, t_id + ".html")
+
+        test_result.log_html_file = os.path.relpath(log_html, out_dir)
+
+        # Render the log if needed
+        if not exists_and_is_newer_than(
+                log_html, [log_file, args.log_template, __file__]):
+            renderLogToHTMLFile(
+                out_dir, log_html, test_result, test_log_data, log_content)
+
+        for tag in test_result.tags:
+            tag_statuses = tags_statuses.setdefault(tag, TagStatuses())
+            if test_result.status == TestStatus.PASSED:
+                tag_statuses.passed_count += 1
+            tag_statuses.present_statuses.add(test_result.status)
+            tag_statuses.present_types.update(test_result.types)
+
+    for tag, tag_statuses in tags_statuses.items():
+        tag_results = tool_results.tags[tag] = TagResults()
+
+        tag_results.passed_tests = tag_statuses.passed_count
+        if len(tag_statuses.present_statuses) == 0:
+            tag_results.status = TestStatus.NA
+        elif len(tag_statuses.present_statuses) == 1:
+            tag_results.status = list(tag_statuses.present_statuses)[0]
+            tool_results.total_tested_tags += 1
+            if (tag_results.status == TestStatus.PASSED):
+                tool_results.total_passed_tags += 1
+        else:
+            tag_results.status = TestStatus.VARIED
+            tool_results.total_tested_tags += 1
+
+        tag_results.types = list(tag_statuses.present_types)
+
+        tag_results.tests = sorted(
+            [t for t in tool_results.tests.values() if tag in t.tags],
+            key=TestResultComp)
+
+    try:
+        with open(os.path.join(args.logs, runner_name, "version")) as f:
+            tool_results.version = f.read().strip()
+    except IOError:
+        pass
+
+    try:
+        with open(os.path.join(args.logs, runner_name, "url")) as f:
+            tool_results.url = f.read().strip()
+    except IOError:
+        pass
+
+    if passed_tests_time == 0:
+        tool_results.passed_throughput = 0
     else:
-        runner_data["passed_throughput"] = runner_data[
-            "passed_size"] / runner_data["passed_time"] / 1024
-    return (runner_data, runner_tag_usage)
+        tool_results.passed_throughput = (
+            passed_tests_input_files_size / passed_tests_time / 1024)
+
+    return tool_results
 
 
-pool = multiprocessing.Pool()
+logger.info("Generating {} from log files in '{}'".format(args.out, args.logs))
+
+# Input files (.sv) path relative to repository's toplevel directory
+all_input_files: Set[str] = set()
+
 runner_names = []
 
 for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
@@ -451,21 +636,27 @@ for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
 
     runner_names.append(runner_name)
 
-results = pool.map(collect_logs, runner_names)
+with multiprocessing.Pool() as pool:
+    results = pool.map(collect_logs, runner_names)
 
-for r, d in zip(runner_names, results):
-    data[r] = d[0]
-    for tag in d[1]:
-        if not tag in database:
-            database[tag] = ''
-        if not tag_usage.get(tag, False):
-            tag_usage[tag] = d[1][tag]
+for tool_name, tool_results in zip(runner_names, results):
+    report_data.tools[tool_name] = tool_results
+    for tag in tool_results.tags:
+        if tag not in database and tag not in report_data.tags:
+            logger.warning("Tag not present in the database: " + tag)
+        report_data.tags.setdefault(
+            tag,
+            TagInfo(description=database.get(tag, ""), url=urls.get(tag, "")))
+    for test_result in tool_results.tests.values():
+        all_input_files.update(test_result.input_files)
 
-pool.close()
-
-for tag in tag_usage:
-    if not tag_usage[tag]:
-        del database[tag]
+# Render input files
+for input_file in all_input_files:
+    input_file_html = os.path.join(out_dir, input_file + ".html")
+    if exists_and_is_newer_than(input_file_html,
+                                [input_file, args.code_template, __file__]):
+        continue
+    renderInputFileToHTMLFile(out_dir, input_file_html, input_file)
 
 # CamelCase or undscore_separator csv headers ?
 # We use CamelCase so that gnuplot getting header from CSV displays them
@@ -485,82 +676,28 @@ csv_header = [
 ]
 
 csv_output = {}
-duplicates = []
 
-for runner in data:
-    for test in data[runner]["tests"]:
-        test_handle = data[runner]["tests"][test]
-        name = test_handle["name"]
-        unique_row = name + ":" + runner
+for tool_name, tool_results in report_data.tools.items():
+    for test_result in tool_results.tests.values():
+        unique_row = test_result.name + ":" + tool_name
 
-        csv_output[unique_row] = {}
-        csv_output[unique_row]["TestName"] = name
-        csv_output[unique_row]["Tool"] = runner
-        csv_output[unique_row]["Pass"] = test_handle["status"] == "test-passed"
-        csv_output[unique_row]["ExitCode"] = test_handle["rc"]
-        csv_output[unique_row]["Tags"] = test_handle["tags"]
-        csv_output[unique_row]["InputBytes"] = test_handle["input_size"]
-        csv_output[unique_row]["AllowedTimeout"] = test_handle["timeout"]
-        csv_output[unique_row]["TimeUser"] = round(
-            float(test_handle["user_time"]), 6)
-        csv_output[unique_row]["TimeSystem"] = round(
-            float(test_handle["system_time"]), 6)
-        csv_output[unique_row]["TimeWall"] = round(
-            float(test_handle["time_elapsed"]), 6)
-        csv_output[unique_row]["RamUsageMiB"] = round(
-            float(test_handle["ram_usage"]) / 1024, 3)
-
-if len(duplicates) > 0:
-    criticalError("Unable to generate report, duplicate test names")
+        csv_output[unique_row] = {
+            "TestName": test_result.name,
+            "Tool": tool_name,
+            "Pass": test_result.status == TestStatus.PASSED,
+            "ExitCode": test_result.exit_code,
+            "Tags": " ".join(test_result.tags),
+            "InputBytes": test_result.total_input_files_size,
+            "AllowedTimeout": test_result.timeout,
+            "TimeUser": round(test_result.user_time, 6),
+            "TimeSystem": round(test_result.system_time, 6),
+            "TimeWall": round(test_result.total_time, 6),
+            "RamUsageMiB": round(test_result.ram_usage / 1024, 3),
+        }
 
 try:
-    for r in data:
-        with open(os.path.join(args.logs, r, "version")) as version_file:
-            data[r]["version"] = version_file.read()
-
-        with open(os.path.join(args.logs, r, "url")) as url_file:
-            data[r]["url"] = url_file.read()
-
-        for tag in data[r]["tags"]:
-            tag_handle = data[r]["tags"][tag]
-
-            tag_handle["logs"] = {}
-
-            for test in data[r]["tests"]:
-                test_handle = data[r]["tests"][test]
-                if tag in test_handle["tags"].split():
-                    tag_handle["logs"][test] = {}
-                    inner = tag_handle["logs"][test]
-                    inner["status"] = test_handle["status"]
-                    inner["name"] = test_handle["name"]
-                    inner["fname"] = test_handle["fname"]
-                    inner["first_file"] = test_handle["first_file"]
-
-            # sort logs
-            tag_handle["logs_sorted"] = sorted(
-                tag_handle["logs"].items(), key=TestTupleComp)
-            if len(tag_handle["logs_sorted"]) > 0:
-                tag_handle["head_test"] = tag_handle["logs_sorted"][0][0]
-
-        data[r]["total"] = {}
-
-        # find the number of tests that passed
-        rts = data[r]["tests"]
-        data[r]["total"]["tests"] = sum(
-            1 for t in rts if rts[t]["status"] in "test-passed")
-
-        # find the number of tags for which all the tests passed
-        rtt = data[r]["tags"]
-        data[r]["total"]["tags"] = sum(
-            1 for t in rtt if rtt[t]["status"] in "test-passed")
-
-        # find the number of tested tags
-        data[r]["total"]["tested_tags"] = sum(
-            1 for t in rtt if rtt[t]["status"] not in "test-na")
-
     with open(args.template, "r") as f:
-        report = jinja2.Template(
-            f.read(), trim_blocks=True, lstrip_blocks=True)
+        report = jinja2env.from_string(f.read())
 
     build_id = os.environ.get('GITHUB_RUN_ID', 'local')
     build_datetime = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -568,9 +705,7 @@ try:
     with open(args.out, 'w') as f:
         f.write(
             report.render(
-                report=data,
-                database=database,
-                database_urls=urls,
+                report=report_data,
                 revision=args.revision,
                 build_id=build_id,
                 datetime=build_datetime))


### PR DESCRIPTION
* Reduced index.html file size

  `index.html` size changed from 9.4M to 385K.
  Details about every tested (tag, tool) pair (a "result cell") has been moved to 4490 (= number of result cells) config files with cumulative size of about 3.3M.
  Config file for a result cell is loaded only when its details panel is opened.

  Numbers above come from a report containing results for 14 tools and 326 tags.

  In case this amount of config files is problematic, it shouldn't be a problem to e.g. merge all configs of a single tag, reducing the number of files to 326.

* URL hash replaced with URL query parameters

  Before: `.../#moore|22.11|22.11--pragma-complex`
  After: `.../?v=moore+22.11+22.11--pragma-complex`

  The hash is still checked and parsed when `v` parameter is absent, so all existing links will work.

  I'm working on an option of generating a report with results split into multiple tables. It could be nice to use the hash as a table anchor.

* Support for browser history. The page title contains a name of currently selected cell result.

  The state is now correctly restored during history navigation. Creation of repeated consecutive history entries on every click (caused by iframes) has been mostly fixed.
  The title looks better in a browser history, example:

  ```
  surelog/uvm-req/22.7--timescale-basic-2 - SystemVerilog Report
  surelog/uvm-req/22.7--timescale-basic-2 - SystemVerilog Report
  slang/uvm-req/22.7--timescale-basic-2 - SystemVerilog Report
  odin/uvm-req/22.7--timescale-basic-2 - SystemVerilog Report
  odin/5.6.4/define-directive - SystemVerilog Report
  moore_parse/5.6.4/define-directive - SystemVerilog Report
  moore_parse/5.6.4/number_test_5 - SystemVerilog Report
  moore_parse/5.6.4/number_test_59 - SystemVerilog Report
  moore_parse/5.6.4/number_test_32 - SystemVerilog Report
  moore_parse/5.6.4/begin-keywords - SystemVerilog Report
  moore/5.6.4/begin-keywords - SystemVerilog Report
  SystemVerilog Report
  ```

* Refactoring mostly in `tools/sv-report` and report.js preparing for "multi-table report" feature and improving the code a bit.
