### PR TITLE
Add results_group property (...and a new filter)

### DIFF
--- a/conf/report/code-template.html
+++ b/conf/report/code-template.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <link rel="stylesheet" type="text/css" href="{{ csspath }}">
+    <link rel="stylesheet" type="text/css" href="{{csspath}}">
   </head>
   <body>
-    {{ filename }}
+    <header><h2>{{filename|e}}</h2></header>
     {{ code }}
   </body>
 </html>

--- a/conf/report/code.css
+++ b/conf/report/code.css
@@ -1,9 +1,10 @@
-body {
-    font-family: "Courier New", Consolas, monospace;
-    font-size: 80%
+@import 'details-view.css';
+
+:root {
+  font-family: "Courier New", Consolas, monospace;
 }
 pre {
-    font-family: "Courier New", Consolas, monospace;
+  margin: 0; padding: 4px;
 }
 
 .highlight .hll { background-color: #ffffcc }
@@ -77,4 +78,3 @@ pre {
 .linenodiv a:hover {
   text-decoration: underline;
 }
-

--- a/conf/report/details-view.css
+++ b/conf/report/details-view.css
@@ -20,7 +20,6 @@ header {
   font-family: sans-serif;
   line-height: 1.4rem;
   padding: 0;
-  line-height: 1rem;
   margin: 0;
   display: grid;
   grid-template-columns: max-content 1fr;

--- a/conf/report/details-view.css
+++ b/conf/report/details-view.css
@@ -1,0 +1,63 @@
+:root {
+  font-family: sans-serif;
+  font-size: 0.8rem;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  min-width: min-content;
+}
+
+header {
+  width: 100%;
+  background-color: #666; color: #fff;
+  font-family: sans-serif;
+  line-height: 1.4rem;
+  padding: 0;
+  line-height: 1rem;
+  margin: 0;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0;
+  justify-content: stretch;
+  justify-items: stretch;
+}
+
+h1 {
+  font-size: 1em;
+  margin: 0;
+  padding: 4px;
+  text-decoration: inherit;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+h2 {
+  font-size: inherit;
+  margin: 0;
+  padding: 4px;
+  color: inherit;
+  font-weight: normal;
+}
+
+header a {
+  display: block;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-position: under;
+  text-decoration-color: #fff4;
+}
+
+header a:hover {
+  background-color: #0004;
+}
+
+pre, code {
+  font-family: "Courier New", Consolas, monospace;
+}

--- a/conf/report/filter.js
+++ b/conf/report/filter.js
@@ -1,32 +1,27 @@
-var table;
-var toolnames = [];
+var tables = [];
+var toolnames = TOOL_NAMES;
 var tool_array = [];
 var col_array = [];
 
-$(document).ready( function () {
-  table = $('#report_table').DataTable( {
+$(document).ready(function () {
+  $('table.dataTable').DataTable({
     paging: false,
-    "autoWidth": false,
-    "order": [[ 1, "asc" ]],
-    "columnDefs": [ { "type": "sv-id", targets: 1 },
-                    { "orderable": false, targets: 0 }],
-    "columns": [
-      null,
-      null,
-      ...Array.from({length: TOOLS_COUNT}, () => (
-        { "orderDataType": "test-status" }
-      ))
+    autoWidth: false,
+
+    order: [ [1, "asc"], ],
+    columns: [
+      { orderable: false },
+      { orderDataType: "original-order", type: "num" },
+      ...TOOL_NAMES.map(() => { return { orderDataType: "simple-fraction", type: "num" } })
     ],
-    initComplete: function() {
-      $("#report_table thead tr th a").each(function(){
-        toolnames.push(this.innerHTML);
-      });
-    }
-  });
-  tool_array = table.columns()[0];
-  tool_array = tool_array.splice(2);
-  col_array = table.columns()[0];
-} );
+  })
+
+  $('table.dataTable').each(function () {
+    tables.push($(this).dataTable().api())
+  })
+  col_array = [...Array(TOOL_NAMES.length+2).keys()]
+  tool_array = [...col_array.slice(2)]
+});
 
 var iter;
 var selected_tools = [];
@@ -46,7 +41,7 @@ const relation_from_string = {
 }
 
 function toggleFilters() {
-  var x = document.getElementById("filter");
+  let x = document.getElementById("filter");
   if (x.style.display === "none") {
     x.style.display = "block";
   } else {
@@ -62,94 +57,98 @@ const filter_types = {
       span_id = parseInt(span_id)
       if ($(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).length > 0)
         $(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).remove()
-      var iter = $(`li[data-uid=${id}] span`).length
+      const iter = $(`li[data-uid=${id}] span`).length
       if (iter === 0)
-        var filter_condition = $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
+        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
       else
-        var filter_condition = $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
-      var filter_entry_operator =  $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      var filter_entry_value =  $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      var filter_condition_options = $('<select onchange="filter_types.coverage.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      for (var i=0; i<this.operators.length; i++)
+        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
+      $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      $('<select onchange="filter_types.coverage.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      for (let i=0; i<this.operators.length; i++)
         $(`<option value="${this.operators[i]}">${this.operators[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-operator`);
-      for (var i=0; i<=100; i++)
+      for (let i=0; i<=100; i++)
         $(`<option value="${i}">${i}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-value`);
     },
     apply: function(operator1, percentage1, operator2, percentage2, relation) {
-      var values = new Set();
-      if (typeof relation == 'undefined') {
-        table.columns().every(function() {
-          var column = this;
-          if(column.index() !== 0 && column.index() !== 1) {
-            percentage = parseInt(percentage1);
-            column.data().each(function(d, j) {
-              output = d.split('/');
-              tests_passed = output[0];
-              total_tests = output[1];
-              coverage = parseInt((tests_passed/total_tests)*100);
-              if ((operator1 in operator_from_string) && operator_from_string[operator1](coverage, percentage))
-                values.add(d);
-            });
-          }
-        });
-      }
-      else {
-        table.columns().every(function() {
-          var column = this;
-          if(column.index() !== 0 && column.index() !== 1) {
-            percentage1 = parseInt(percentage1);
-            percentage2 = parseInt(percentage2);
-            column.data().each(function(d, j) {
-              output = d.split('/');
-              tests_passed = output[0];
-              total_tests = output[1];
-              coverage = parseInt((tests_passed/total_tests)*100);
-              const result_left = operator_from_string[operator1](coverage, percentage1);
-              const result_right = operator_from_string[operator2](coverage, percentage2);
-              const result = relation_from_string[relation](result_left, result_right);
-              if (result)
-                values.add(d);
-            });
-          }
-        });
-      }
-      values = [...values];
-      if (selected_tools.length === 0){
-        table.columns(col_array).every(function() {
-          $.fn.dataTable.ext.search.push(
-            function(settings, searchData, index, rowData, counter) {
-              for(var i=0; i<col_array.length; i++){
-                if(values.includes(searchData[col_array[i]]))
-                  return true;
-              }
-          });
-        });
-      }
-      else {
-        table.columns(selected_tools).every(function() {
-          if (tool_relation !== 'and'){
-            $.fn.dataTable.ext.search.push(
-              function(settings, searchData, index, rowData, counter) {
-                for(var i=0; i<selected_tools.length; i++){
-                  if(values.includes(searchData[selected_tools[i]]))
-                    return true;
-                }
-            });
-          }
-          else if (tool_relation === 'and'){
-            regex = [];
-            for (var i=0; i<values.length; i++){
-              value = "^"+values[i]+"$";
-              regex.push(value);
+      let values = new Set()
+      for (const table of tables) {
+        if (typeof relation == 'undefined') {
+          table.columns().every(function () {
+            let column = this
+            if (column.index() !== 0 && column.index() !== 1) {
+              percentage = parseInt(percentage1)
+              column.data().each(function (d, j) {
+                output = d.split('/')
+                tests_passed = output[0]
+                total_tests = output[1]
+                coverage = parseInt((tests_passed / total_tests) * 100)
+                if ((operator1 in operator_from_string) && operator_from_string[operator1](coverage, percentage))
+                  values.add(d)
+              })
             }
-            regex = regex.join("|");
-            table.columns(selected_tools).search(regex, true, false, true).draw();
-          }
-        });
+          })
+        }
+        else {
+          table.columns().every(function () {
+            let column = this
+            if (column.index() !== 0 && column.index() !== 1) {
+              percentage1 = parseInt(percentage1)
+              percentage2 = parseInt(percentage2)
+              column.data().each(function (d, j) {
+                output = d.split('/')
+                tests_passed = output[0]
+                total_tests = output[1]
+                coverage = parseInt((tests_passed / total_tests) * 100)
+                const result_left = operator_from_string[operator1](coverage, percentage1)
+                const result_right = operator_from_string[operator2](coverage, percentage2)
+                const result = relation_from_string[relation](result_left, result_right)
+                if (result)
+                  values.add(d)
+              })
+            }
+          })
+        }
       }
-      table.draw();
-    }
-  },
+
+      values = [...values]
+      if (selected_tools.length === 0) {
+        $.fn.dataTable.ext.search.push(
+          function (settings, searchData, index, rowData, counter) {
+            for (let i = 0; i < col_array.length; i++) {
+              if (values.includes(searchData[col_array[i]]))
+                return true
+            }
+          })
+      }
+      else {
+        if (tool_relation !== 'and') {
+          $.fn.dataTable.ext.search.push(
+            function (settings, searchData, index, rowData, counter) {
+              for (let i = 0; i < selected_tools.length; i++) {
+                if (values.includes(searchData[selected_tools[i]]))
+                  return true
+              }
+            })
+        }
+        else if (tool_relation === 'and') {
+          regex = []
+          for (let i = 0; i < values.length; i++) {
+            value = "^" + values[i] + "$"
+            regex.push(value)
+          }
+          regex = regex.join("|")
+
+          for (const table of tables) {
+            table.columns(selected_tools).search(regex, true, false, true).draw()
+          }
+        }
+      }
+      for (const table of tables) {
+        table.draw()
+      }
+    } // .apply()
+  }, // .coverage
   type: {
     name: "Type",
     operators: ["is", "is not"],
@@ -158,17 +157,17 @@ const filter_types = {
       span_id = parseInt(span_id)
       if ($(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).length > 0)
         $(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).remove()
-      var iter = $(`li[data-uid=${id}] span`).length
+      const iter = $(`li[data-uid=${id}] span`).length
       if (iter === 0)
-        var filter_condition = $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
+        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
       else
-        var filter_condition = $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
-      var filter_entry_operator =  $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      var filter_entry_value =  $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      var filter_condition_options = $('<select onchange="filter_types.type.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      for (var i=0; i<this.operators.length; i++)
+        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
+      $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      $('<select onchange="filter_types.type.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      for (let i=0; i<this.operators.length; i++)
         $(`<option value="${this.operators[i]}">${this.operators[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-operator`);
-      for (var i=0; i<this.types.length; i++)
+      for (let i=0; i<this.types.length; i++)
         $(`<option value="${this.types[i]}">${this.types[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-value`);
     },
     apply: function(operator1, type1, operator2, type2, relation) {
@@ -176,9 +175,9 @@ const filter_types = {
         $.fn.dataTable.ext.search.push(
           function(settings, data, dataIndex){
             if (operator1 === 'is')
-              return $(table.row(dataIndex).node()).hasClass(type1);
+              return $(settings.row(dataIndex).node()).hasClass(type1);
             else if (operator1 === 'is not')
-              return !$(table.row(dataIndex).node()).hasClass(type1);
+              return !$(settings.row(dataIndex).node()).hasClass(type1);
           });
       }
       else {
@@ -186,30 +185,30 @@ const filter_types = {
           function(settings, data, dataIndex){
             if (relation === 'and'){
               if (operator1 === 'is' && operator2 === 'is')
-                return (($(table.row(dataIndex).node()).hasClass(type1)) && ($(table.row(dataIndex).node()).hasClass(type2)));
+                return (($(settings.row(dataIndex).node()).hasClass(type1)) && ($(settings.row(dataIndex).node()).hasClass(type2)));
               else if (operator1 === 'is' && operator2 === 'is not')
-              return (($(table.row(dataIndex).node()).hasClass(type1)) && (!$(table.row(dataIndex).node()).hasClass(type2)));
+              return (($(settings.row(dataIndex).node()).hasClass(type1)) && (!$(settings.row(dataIndex).node()).hasClass(type2)));
               else if (operator1 === 'is not' && operator2 === 'is')
-              return ((!$(table.row(dataIndex).node()).hasClass(type1)) && ($(table.row(dataIndex).node()).hasClass(type2)));
+              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) && ($(settings.row(dataIndex).node()).hasClass(type2)));
               else if (operator1 === 'is not' && operator2 === 'is not')
-              return ((!$(table.row(dataIndex).node()).hasClass(type1)) && (!$(table.row(dataIndex).node()).hasClass(type2)));
+              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) && (!$(settings.row(dataIndex).node()).hasClass(type2)));
             }
             else if (relation === 'or'){
               if (operator1 === 'is' && operator2 === 'is')
-                return (($(table.row(dataIndex).node()).hasClass(type1)) || ($(table.row(dataIndex).node()).hasClass(type2)));
+                return (($(settings.row(dataIndex).node()).hasClass(type1)) || ($(settings.row(dataIndex).node()).hasClass(type2)));
               else if (operator1 === 'is' && operator2 === 'is not')
-              return (($(table.row(dataIndex).node()).hasClass(type1)) || (!$(table.row(dataIndex).node()).hasClass(type2)));
+              return (($(settings.row(dataIndex).node()).hasClass(type1)) || (!$(settings.row(dataIndex).node()).hasClass(type2)));
               else if (operator1 === 'is not' && operator2 === 'is')
-              return ((!$(table.row(dataIndex).node()).hasClass(type1)) || ($(table.row(dataIndex).node()).hasClass(type2)));
+              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) || ($(settings.row(dataIndex).node()).hasClass(type2)));
               else if (operator1 === 'is not' && operator2 === 'is not')
-              return ((!$(table.row(dataIndex).node()).hasClass(type1)) || (!$(table.row(dataIndex).node()).hasClass(type2)));
+              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) || (!$(settings.row(dataIndex).node()).hasClass(type2)));
             }
           }
         );
       }
-      table.draw();
-    }
-  },
+      tables.forEach((table) => table.draw())
+    } // .apply()
+  }, // .type
   tool: {
     name: "Tool",
     operators: ["is", "is not"],
@@ -218,45 +217,47 @@ const filter_types = {
       span_id = parseInt(span_id)
       if ($(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).length > 0)
         $(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).remove()
-      var iter = $(`li[data-uid=${id}] span`).length
+      const iter = $(`li[data-uid=${id}] span`).length
       if (iter === 0)
-        var filter_condition = $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
+        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
       else
-        var filter_condition = $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
-      var filter_entry_operator =  $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      var filter_entry_value =  $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      var filter_condition_options = $('<select onchange="filter_types.tool.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      for (var i=0; i<this.operators.length; i++)
+        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
+      $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      $('<select onchange="filter_types.tool.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
+      for (let i=0; i<this.operators.length; i++)
         $(`<option value="${this.operators[i]}">${this.operators[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-operator`);
-      for (var i=0; i<this.tools.length; i++)
+      for (let i=0; i<this.tools.length; i++)
         $(`<option value="${this.tools[i]}">${this.tools[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-value`);
     },
     apply: function(operator, tool) {
-      table.columns(col_array).visible(true);
-      table.columns(tool_array).every(function() {
-        var column = this;
-        if(column.index() !== 0 && column.index() !== 1){
-          var theadname = column.header().textContent.trim();
-          if(operator === 'is'){
-            if(theadname === tool){
-              var index = tool_array.indexOf(column.index());
-              tool_array.splice(index, 1);
-              selected_tools.push(column.index());
+      for (const table of tables) {
+        table.columns(col_array).visible(true)
+        table.columns(tool_array).every(function () {
+          let column = this
+          if (column.index() !== 0 && column.index() !== 1) {
+            let theadname = column.header().textContent.trim()
+            if (operator === 'is') {
+              if (theadname === tool) {
+                let index = tool_array.indexOf(column.index())
+                tool_array.splice(index, 1)
+                selected_tools.push(column.index())
+              }
+            }
+            else if (operator === 'is not') {
+              if (theadname !== tool) {
+                let index = tool_array.indexOf(column.index())
+                tool_array.splice(index, 1)
+                selected_tools.push(column.index())
+              }
             }
           }
-          else if(operator === 'is not'){
-            if(theadname !== tool){
-              var index = tool_array.indexOf(column.index());
-              tool_array.splice(index, 1);
-              selected_tools.push(column.index());
-            }
-          }
-        }
-      });
-      table.columns(tool_array).visible(false);
-    }
-  }
-}
+        })
+        table.columns(tool_array).visible(false)
+      }
+    } // .apply()
+  } // .tool
+} // filter_types
 
 function entryChanged(mode, id) {
   $(`li[data-uid=${id}] span`).remove();
@@ -264,51 +265,55 @@ function entryChanged(mode, id) {
 }
 
 function applyFilter() {
-  tool_array = table.columns()[0];
-  tool_array = tool_array.splice(2);
-  table.columns(col_array).every(function() {
-    $.fn.dataTable.ext.search.pop();
-  });
-  table.columns(col_array).search("").draw();
-  table.columns(col_array).visible(true);
-  $.fn.dataTable.ext.search.pop();
-  table.draw();
-  $('.filter-remove').show();
-  var applied_filters = [];
-  $('.filter-entries').find('li').each(function(){
-    var object = {};
-    object['filter'] = $(this).find('.filter-entry-type').val();
-    if (object['filter'] === 'tool')
-      object['priority'] = 1
-    else
-      object['priority'] = 0
-    $(this).find('span').each(function(index){
-      var span = {};
-      span['relation'] = $(this).find('.filter-condition').val();
-      span['operator'] = $(this).find('.filter-entry-operator').val();
-      span['value'] = $(this).find('.filter-entry-value').val();
-      object[index] = span;
-    });
-    applied_filters.push(object);
-  });
-  applied_filters.sort((a, b) => (a.priority < b.priority) ? 1 : -1);
-  for(const key in applied_filters){
-    if (applied_filters[key]['filter'] === 'tool')
-      tool_relation = applied_filters[key][0]['relation'];
-    if (applied_filters[key]['filter'] !== 'tool' && (Object.keys(applied_filters[key]).length-2 === 2))
-      filter_types[applied_filters[key]['filter']].apply(applied_filters[key][0]['operator'], applied_filters[key][0]['value'], applied_filters[key][1]['operator'], applied_filters[key][1]['value'], applied_filters[key][0]['relation']);
-    else {
-    for (var i=0; i<Object.keys(applied_filters[key]).length-2; i++)
-      filter_types[applied_filters[key]['filter']].apply(applied_filters[key][i]['operator'], applied_filters[key][i]['value']);
+  for (const table of tables) {
+    tool_array = table.columns()[0]
+    tool_array = tool_array.splice(2)
+    table.columns(col_array).every(function () {
+      $.fn.dataTable.ext.search.pop()
+    })
+    table.columns(col_array).search("").draw()
+    table.columns(col_array).visible(true)
+    $.fn.dataTable.ext.search.pop()
+    table.draw()
+    $('.filter-remove').show()
+    let applied_filters = []
+    $('.filter-entries').find('li').each(function () {
+      let object = {}
+      object['filter'] = $(this).find('.filter-entry-type').val()
+      if (object['filter'] === 'tool')
+        object['priority'] = 1
+      else
+        object['priority'] = 0
+      $(this).find('span').each(function (index) {
+        let span = {}
+        span['relation'] = $(this).find('.filter-condition').val()
+        span['operator'] = $(this).find('.filter-entry-operator').val()
+        span['value'] = $(this).find('.filter-entry-value').val()
+        object[index] = span
+      })
+      applied_filters.push(object)
+    })
+    applied_filters.sort((a, b) => (a.priority < b.priority) ? 1 : -1)
+    for (const key in applied_filters) {
+      if (applied_filters[key]['filter'] === 'tool')
+        tool_relation = applied_filters[key][0]['relation']
+      if (applied_filters[key]['filter'] !== 'tool' && (Object.keys(applied_filters[key]).length - 2 === 2))
+        filter_types[applied_filters[key]['filter']].apply(applied_filters[key][0]['operator'], applied_filters[key][0]['value'], applied_filters[key][1]['operator'], applied_filters[key][1]['value'], applied_filters[key][0]['relation'])
+      else {
+        for (let i = 0; i < Object.keys(applied_filters[key]).length - 2; i++)
+          filter_types[applied_filters[key]['filter']].apply(applied_filters[key][i]['operator'], applied_filters[key][i]['value'])
+      }
     }
   }
 }
 
 function removeAll() {
-  table.columns(col_array).search("").draw();
-  table.columns(col_array).visible(true);
-  $.fn.dataTable.ext.search.pop();
-  table.draw();
+  $.fn.dataTable.ext.search.pop()
+  for (const table of tables) {
+    table.columns(col_array).search("").draw()
+    table.columns(col_array).visible(true)
+    table.draw()
+  }
   $('li').remove();
   $('.filter-apply').hide();
   $('.filter-remove').hide();
@@ -321,10 +326,12 @@ function removeEntry(parent, col_array) {
   if (iter === 0){
     $('.filter-apply').hide();
     $('.filter-remove').hide();
-    table.columns(col_array).search("").draw();
-    table.columns(col_array).visible(true);
-    $.fn.dataTable.ext.search.pop();
-    table.draw();
+    $.fn.dataTable.ext.search.pop()
+    for (const table of tables) {
+      table.columns(col_array).search("").draw()
+      table.columns(col_array).visible(true)
+      table.draw()
+    }
   }
 }
 
@@ -332,13 +339,12 @@ function addOptions() {
   iter = $('.filter-entries').children('li').length;
   if(iter === 0)
     $('.filter-apply').show();
-  var filter_entries = $(`<li data-uid=${iter}></li>`).appendTo('.filter-entries');
-  var filter_entry_type =  $('<select class="filter-entry-type" onchange="entryChanged(this.value, this.parentElement.dataset.uid)"><option value=""></option></select>').appendTo(filter_entries)
-  var remove = $('<i class="fas fa-minus-circle filter-clear" onclick="removeEntry(this.parentElement, col_array)"></i>').insertAfter(filter_entry_type);
+  const filter_entries = $(`<li data-uid=${iter}></li>`).appendTo('.filter-entries');
+  const filter_entry_type =  $('<select class="filter-entry-type" onchange="entryChanged(this.value, this.parentElement.dataset.uid)"><option value=""></option></select>').appendTo(filter_entries)
+  $('<i class="fas fa-minus-circle filter-clear" onclick="removeEntry(this.parentElement, col_array)"></i>').insertAfter(filter_entry_type);
 
   for (const key in filter_types){
     filter_entry_type.append(`<option value=${key}>${filter_types[key].name}</option>`);
   }
   iter = iter + 1;
 }
-

--- a/conf/report/filter.js
+++ b/conf/report/filter.js
@@ -1,9 +1,398 @@
-var tables = [];
-var toolnames = TOOL_NAMES;
-var tool_array = [];
-var col_array = [];
+// NOTE: Code here uses classes and functions from report.js
 
-$(document).ready(function () {
+const HEADER_COLUMNS_COUNT = 2
+
+/// Filter state manager ///////////////////////////////////////////////
+
+const filter_state = new StateManager({
+  hidden_column_ids: {
+    initial: [],
+    validator: (v) => Array.isArray(v),
+  },
+  row_filter_func: {
+    initial: null,
+    validator: (v) => (typeof v === "function" || v === null)
+  },
+  cell_filter_func: {
+    initial: null,
+    validator: (v) => (typeof v === "function" || v === null)
+  },
+
+  tool_filter: {
+    initial: TOOL_NAMES.map((v) => v.toLowerCase()).sort(),
+    validator: (v) => (Array.isArray(v) && v.every((v) => is_string(v))),
+  },
+  applied_tool_filter: {
+    initial: TOOL_NAMES.map((v) => v.toLowerCase()).sort(),
+    validator: (v) => (Array.isArray(v) && v.every((v) => is_string(v))),
+  },
+
+  coverage_filter: {
+    initial: [">=", 0],
+    validator: (v) => Array.isArray(v),
+  },
+  applied_coverage_filter: {
+    initial: [">=", 0],
+    validator: (v) => Array.isArray(v),
+  },
+
+  type_filter: {
+    initial: ["elaboration", "parsing", "simulation"],
+    validator: (v) => (Array.isArray(v) && v.every((v) => is_string(v))),
+  },
+  applied_type_filter: {
+    initial: ["elaboration", "parsing", "simulation"],
+    validator: (v) => (Array.isArray(v) && v.every((v) => is_string(v))),
+  },
+})
+
+/// EntriesListController //////////////////////////////////////////////
+
+class CoverageFilterEntriesController {
+  constructor(state_manager, element) {
+    this._state = state_manager
+
+    this._top = element
+    this._first_entry = this._top.querySelector(".p_entry")
+    this._first_operator = this._first_entry.querySelector(".p_entry-operator")
+    this._first_value = this._first_entry.querySelector(".p_entry-value");
+
+    [this._first_operator, this._first_value].forEach((element) => {
+      element.addEventListener("change", this._update_state.bind(this))
+    })
+
+    this._entry_template = this._top.querySelector(".p_entry-template")
+    this._add_button = this._top.querySelector(".p_add-entry-button")
+
+    this._add_button.onclick = this._add_entry_button_clicked.bind(this)
+
+    this._state.subscribe(
+        ["coverage_filter"],
+        StateManager.debounce(this._state_changed.bind(this)))
+
+    this._update_state_handle = null
+  }
+
+  static _select_option(select_element, option_value) {
+    let i = 0
+    for (const child of select_element.options) {
+      if (child.value === option_value) {
+        select_element.selectedIndex = i
+        return
+      }
+      ++i
+    }
+    select_element.selectedIndex = -1
+  }
+
+  _state_changed(state, changed_values) {
+    let entries = [...this._top.querySelectorAll(".p_entry.v_removable")]
+    const values = state.coverage_filter
+    const expected_removable_entries_count = (values.length - 2) / 3
+
+    if (entries.length > expected_removable_entries_count) {
+      for (let i = expected_removable_entries_count; i < entries.length; ++i) {
+        entries[i].remove()
+      }
+      entries.splice(expected_removable_entries_count)
+    } else if (entries.length < expected_removable_entries_count) {
+      let last_entry = entries.length > 0 ? entries[entries.lenght-1] : this._first_entry
+      for (let i = entries.length; i < expected_removable_entries_count; ++i) {
+        const new_entry = this._create_entry()
+        last_entry.after(new_entry)
+        entries.push(new_entry)
+        last_entry = new_entry
+      }
+    }
+
+    CoverageFilterEntriesController._select_option(this._first_operator, values[0])
+    this._first_value.value = values[1]
+
+    let i = 2
+    for (const entry of entries) {
+      CoverageFilterEntriesController._select_option(entry.querySelector(".p_entry-relation"), values[i+0])
+      CoverageFilterEntriesController._select_option(entry.querySelector(".p_entry-operator"), values[i+1])
+      entry.querySelector(".p_entry-value").value = values[i + 2]
+      i += 3
+    }
+  }
+
+  _add_entry_button_clicked(event) {
+    const entries = this._top.querySelectorAll(".p_entry")
+    const last_entry = entries[entries.length - 1]
+    const new_entry = this._create_entry()
+    last_entry.after(new_entry)
+    new_entry.querySelector("select, input, button").focus()
+    this._update_state()
+  }
+
+  _update_state() {
+    if (this._update_state_handle !== null)
+      clearTimeout(this._update_state_handle)
+
+    this._update_state_handle = setTimeout(() => {
+      this._update_state_handle = null
+
+      const entries = this._top.querySelectorAll(".p_entry.v_removable")
+      const new_state = new Array(2 + 3 * (entries.length))
+
+      new_state[0] = this._first_operator.value
+      if (this._first_value.validity.valid)
+        new_state[1] = this._first_value.valueAsNumber|0
+      else
+        new_state[1] = NaN
+
+      let i = 2
+      for (const entry of entries) {
+        new_state[i+0] = entry.querySelector(".p_entry-relation").value
+        new_state[i+1] = entry.querySelector(".p_entry-operator").value
+        const value_field = entry.querySelector(".p_entry-value")
+        if (value_field.validity.valid)
+          new_state[i + 2] = value_field.valueAsNumber|0
+        else
+          new_state[i + 2] = NaN
+        i += 3
+      }
+
+      this._state.state.coverage_filter = new_state
+    }, 100)
+  }
+
+  _create_entry() {
+    const entry = this._entry_template.content.firstElementChild.cloneNode(true)
+
+    entry.querySelectorAll("select, input").forEach((element) => {
+      element.addEventListener("change", this._update_state.bind(this))
+    })
+
+    const remove_button = entry.querySelector(".p_remove-entry-button")
+    remove_button.onclick = (event) => {
+      entry.remove()
+      this._update_state()
+    }
+
+    return entry
+  }
+}
+
+/// CheckboxGroupController ////////////////////////////////////////////
+
+class CheckboxGroupController {
+  constructor(state_manager, state_key, checkbox_list) {
+    this._state = state_manager
+    this._key = state_key
+    this._checkboxes = new Map()
+    this._selections = new Set(this._state.state[this._key])
+
+    for (const checkbox of checkbox_list) {
+      this._checkboxes.set(checkbox.value, checkbox)
+      checkbox.checked = this._selections.has(checkbox.value)
+      checkbox.addEventListener("change", this._checkbox_changed.bind(this))
+    }
+
+    this._state.subscribe(
+        [state_key],
+        StateManager.debounce(this._state_changed.bind(this)))
+
+    this._update_state_handle = null
+  }
+
+  _state_changed(state, changed_values) {
+    this._selections = new Set(state[this._key])
+    for (const [value, checkbox] of this._checkboxes) {
+      checkbox.checked = this._selections.has(value)
+    }
+  }
+
+  _checkbox_changed(event) {
+    const checkbox = event.target
+    if (checkbox.checked == this._selections.has(checkbox.value))
+      return
+
+    if (checkbox.checked) {
+      this._selections.add(checkbox.value)
+    } else {
+      this._selections.delete(checkbox.value)
+    }
+
+    if (this._update_state_handle === null) {
+      this._update_state_handle = setTimeout(() => {
+        this._update_state_handle = null
+        this._state.state[this._key] = [...this._selections].sort()
+      }, 0)
+    }
+  }
+}
+
+/// FilterController ///////////////////////////////////////////////////
+
+class FilterController {
+  constructor(state_manager, elements) {
+    this._state = state_manager
+    this._apply_button = elements.apply_button
+    this._reset_button = elements.reset_button
+    this._error_label = elements.error_label
+
+    this._apply_button.onclick = this._apply_clicked.bind(this)
+    this._reset_button.onclick = this._reset_clicked.bind(this)
+
+    this._state.subscribe(
+        ["tool_filter", "coverage_filter", "type_filter", "applied_tool_filter", "applied_coverage_filter", "applied_type_filter"],
+        StateManager.debounce(this._state_changed.bind(this)))
+  }
+
+  static _is_filter_valid(key, value) {
+    const VALID_OPERATORS = new Set([">=", "<=", ">", "<", "=="])
+    const VALID_RELATIONS = new Set(["&&", "||"])
+
+    switch (key) {
+      case "tool_filter":
+      case "type_filter":
+        return value.length > 0
+
+      case "coverage_filter": {
+        if (value.length < 2 || ((value.length - 2) % 3) !== 0)
+          return false
+        if (!VALID_OPERATORS.has(value[0]) || !isFinite(value[1]) || value[1] < 0 || value[1] > 100)
+          return false
+        for (let i = 2; i < value.length; i += 3) {
+          if (!VALID_RELATIONS.has(value[i+0])) return false
+          if (!VALID_OPERATORS.has(value[i+1])) return false
+          if (!isFinite(value[i+2]) || value[i+2] < 0 || value[i+2] > 100) return false
+        }
+        return true
+      }
+    }
+  }
+
+  _state_changed(state, changed_values) {
+    let apply_possible = false;
+    let reset_possible = false;
+    const ERROR_MSGS = {
+      tool_filter: "No tool selected.",
+      coverage_filter: "Invalid coverage value(s).",
+      type_filter: "No type selected.",
+    }
+    const ERROR_MSG_PREFIX = "<strong>Error(s):</strong> "
+    const errors = []
+
+    for (const key of ["tool_filter", "coverage_filter", "type_filter"]) {
+      if (!deep_eq(state[key], this._state.state_spec[key].initial))
+        reset_possible = true
+      if (!deep_eq(state[key], state[`applied_${key}`]))
+        apply_possible = true
+      if (!FilterController._is_filter_valid(key, state[key]))
+        errors.push(ERROR_MSGS[key])
+    }
+
+    if (errors.length > 0)
+      this._error_label.innerHTML = ERROR_MSG_PREFIX + errors.join(" ")
+    else
+      this._error_label.innerText = ""
+
+    this._apply_button.disabled = (errors.length != 0) || !apply_possible;
+    this._reset_button.disabled = !reset_possible;
+  }
+
+  _apply_clicked(event) {
+    const tool_filter = this._state.state.tool_filter
+    const coverage_filter = this._state.state.coverage_filter
+    const type_filter = this._state.state.type_filter
+
+    this._state.state.applied_tool_filter = tool_filter
+    this._state.state.applied_coverage_filter = coverage_filter
+    this._state.state.applied_type_filter = type_filter
+
+    if (!(coverage_filter.length === 2 && (
+          (coverage_filter[0] === ">=" && coverage_filter[1] === 0) ||
+          (coverage_filter[0] === "<=" && coverage_filter[1] === 100)
+        ))) {
+      const operator = coverage_filter[0]
+      const value = coverage_filter[1]
+      let coverage_filter_code = `(coverage ${operator} ${value})`
+      for (let i = 2; i < coverage_filter.length; i += 3) {
+        const relation = coverage_filter[i + 0]
+        const operator = coverage_filter[i + 1]
+        const value = coverage_filter[i + 2]
+        coverage_filter_code += ` ${relation} (coverage ${operator} ${value})`
+      }
+
+      const cell_filter_func_code = `(coverage) => { return (${coverage_filter_code}) }`
+      Log.dbg("filter", "Cell filter function: %o", cell_filter_func_code)
+      const cell_filter_func = eval(cell_filter_func_code)
+      this._state.state.cell_filter_func = cell_filter_func
+    } else {
+      this._state.state.cell_filter_func = null
+    }
+
+    if (!deep_eq(type_filter, this._state.state_spec.type_filter.initial)) {
+      const type_filter_codes = []
+      for (const type of type_filter)
+        type_filter_codes.push(`(types.includes("${type}"))`)
+      const type_filter_code = type_filter_codes.join(" || ")
+
+      const row_filter_func_code = `(types) => { return (${type_filter_code}) }`
+      Log.dbg("filter", "Row filter function: %o", row_filter_func_code)
+      const row_filter_func = eval(row_filter_func_code)
+      this._state.state.row_filter_func = row_filter_func
+    } else {
+      this._state.state.row_filter_func = null
+    }
+
+    const hidden_column_ids = []
+    let i = HEADER_COLUMNS_COUNT
+    for (const tool of TOOL_NAMES) {
+      if (!tool_filter.includes(tool.toLowerCase()))
+        hidden_column_ids.push(i)
+      ++i
+    }
+    this._state.state.hidden_column_ids = hidden_column_ids
+  }
+
+  _reset_clicked(event) {
+    for (const key of ["tool_filter", "coverage_filter", "type_filter"]) {
+      this._state.state[key] = this._state.state_spec[key].initial
+    }
+  }
+}
+
+/// DataTable filter function that does actual filtering ///////////////
+
+$.fn.dataTable.ext.search.push(function (settings, searchData, index, rowData, counter) {
+  if (filter_state.state.row_filter_func) {
+    const dt = settings.oInstance.DataTable();
+    const types = dt.row(index).node().dataset.types.split(" ")
+    if (!filter_state.state.row_filter_func(types))
+      return false
+  }
+  if (filter_state.state.cell_filter_func) {
+    const hidden_column_ids = filter_state.state.hidden_column_ids
+    const cell_filter_func = filter_state.state.cell_filter_func
+    let i = 0
+    let has_matching_cell = false;
+    for (let col = HEADER_COLUMNS_COUNT; col < rowData.length; ++col) {
+      if (col === hidden_column_ids[i]) {
+        ++i
+        continue
+      }
+      const coverage = Math.round(parseSimpleFraction(rowData[col]) * 100)|0
+      if (cell_filter_func(coverage)) {
+        has_matching_cell = true
+        break
+      }
+    }
+    if (!has_matching_cell)
+      return false
+  }
+  return true
+})
+
+/// Main ///////////////////////////////////////////////////////////////
+
+window.addEventListener('DOMContentLoaded', function(event) {
+
+  // DataTable
+
   $('table.dataTable').DataTable({
     paging: false,
     autoWidth: false,
@@ -12,339 +401,72 @@ $(document).ready(function () {
     columns: [
       { orderable: false },
       { orderDataType: "original-order", type: "num" },
-      ...TOOL_NAMES.map(() => { return { orderDataType: "simple-fraction", type: "num" } })
+      ...TOOL_NAMES.map(() => {
+        return {
+          orderDataType: "simple-fraction",
+          type: "num",
+        }
+      })
     ],
   })
 
+  // Update tables when a filter is applied
+
+  const tables = []
   $('table.dataTable').each(function () {
-    tables.push($(this).dataTable().api())
+    const table = $(this).dataTable().api()
+    tables.push(table)
+
+    filter_state.subscribe(
+      ["hidden_column_ids", "row_filter_func", "cell_filter_func"],
+      StateManager.debounce((state, changed_values) => tables.forEach((table) => {
+        if (changed_values.has("hidden_column_ids")) {
+          table.columns().visible(true)
+          table.columns(state.hidden_column_ids).visible(false)
+        }
+
+        setTimeout(()=>table.draw(), 0)
+    }), 0))
   })
-  col_array = [...Array(TOOL_NAMES.length+2).keys()]
-  tool_array = [...col_array.slice(2)]
-});
 
-var iter;
-var selected_tools = [];
-var tools_relation;
+  // Filter
 
-const operator_from_string = {
-  '<': (a, b) => a < b,
-  '>': (a, b) => a > b,
-  '>=': (a, b) => a >= b,
-  '<=': (a, b) => a <= b,
-  '=': (a, b) => a === b
-};
+  const filter_section = document.querySelector("#filter-section")
 
-const relation_from_string = {
-  'and': (a, b) => a && b,
-  'or': (a, b) => a || b
-}
+  const filter_controller = new FilterController(filter_state, {
+    apply_button: document.getElementById("filter-apply-button"),
+    reset_button: document.getElementById("filter-reset-button"),
+    error_label: document.getElementById("filter-error-msg"),
+  })
 
-function toggleFilters() {
-  let x = document.getElementById("filter");
-  if (x.style.display === "none") {
-    x.style.display = "block";
-  } else {
-    x.style.display = "none";
-  }
-}
+  // Tool filter
 
-const filter_types = {
-  coverage: {
-    name: "Coverage",
-    operators: ["<", "<=", ">", ">=", "="],
-    value_field_factory: function(id, span_id=0) {
-      span_id = parseInt(span_id)
-      if ($(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).length > 0)
-        $(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).remove()
-      const iter = $(`li[data-uid=${id}] span`).length
-      if (iter === 0)
-        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
-      else
-        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
-      $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      $('<select onchange="filter_types.coverage.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      for (let i=0; i<this.operators.length; i++)
-        $(`<option value="${this.operators[i]}">${this.operators[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-operator`);
-      for (let i=0; i<=100; i++)
-        $(`<option value="${i}">${i}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-value`);
-    },
-    apply: function(operator1, percentage1, operator2, percentage2, relation) {
-      let values = new Set()
-      for (const table of tables) {
-        if (typeof relation == 'undefined') {
-          table.columns().every(function () {
-            let column = this
-            if (column.index() !== 0 && column.index() !== 1) {
-              percentage = parseInt(percentage1)
-              column.data().each(function (d, j) {
-                output = d.split('/')
-                tests_passed = output[0]
-                total_tests = output[1]
-                coverage = parseInt((tests_passed / total_tests) * 100)
-                if ((operator1 in operator_from_string) && operator_from_string[operator1](coverage, percentage))
-                  values.add(d)
-              })
-            }
-          })
-        }
-        else {
-          table.columns().every(function () {
-            let column = this
-            if (column.index() !== 0 && column.index() !== 1) {
-              percentage1 = parseInt(percentage1)
-              percentage2 = parseInt(percentage2)
-              column.data().each(function (d, j) {
-                output = d.split('/')
-                tests_passed = output[0]
-                total_tests = output[1]
-                coverage = parseInt((tests_passed / total_tests) * 100)
-                const result_left = operator_from_string[operator1](coverage, percentage1)
-                const result_right = operator_from_string[operator2](coverage, percentage2)
-                const result = relation_from_string[relation](result_left, result_right)
-                if (result)
-                  values.add(d)
-              })
-            }
-          })
-        }
+  const tool_filter = filter_section.querySelector(".p_tool-filter")
+  const tool_filter_checkboxes = tool_filter.querySelectorAll("input[type='checkbox']")
+
+  tool_filter.querySelector(".p_select-all-button").onclick = (event) => {
+    tool_filter_checkboxes.forEach((element) => {
+      if (!element.checked) {
+        element.checked = true
+        element.dispatchEvent(new Event("change"))
       }
-
-      values = [...values]
-      if (selected_tools.length === 0) {
-        $.fn.dataTable.ext.search.push(
-          function (settings, searchData, index, rowData, counter) {
-            for (let i = 0; i < col_array.length; i++) {
-              if (values.includes(searchData[col_array[i]]))
-                return true
-            }
-          })
-      }
-      else {
-        if (tool_relation !== 'and') {
-          $.fn.dataTable.ext.search.push(
-            function (settings, searchData, index, rowData, counter) {
-              for (let i = 0; i < selected_tools.length; i++) {
-                if (values.includes(searchData[selected_tools[i]]))
-                  return true
-              }
-            })
-        }
-        else if (tool_relation === 'and') {
-          regex = []
-          for (let i = 0; i < values.length; i++) {
-            value = "^" + values[i] + "$"
-            regex.push(value)
-          }
-          regex = regex.join("|")
-
-          for (const table of tables) {
-            table.columns(selected_tools).search(regex, true, false, true).draw()
-          }
-        }
-      }
-      for (const table of tables) {
-        table.draw()
-      }
-    } // .apply()
-  }, // .coverage
-  type: {
-    name: "Type",
-    operators: ["is", "is not"],
-    types: ["parsing", "preprocessing", "simulation"],
-    value_field_factory: function(id, span_id=0) {
-      span_id = parseInt(span_id)
-      if ($(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).length > 0)
-        $(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).remove()
-      const iter = $(`li[data-uid=${id}] span`).length
-      if (iter === 0)
-        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
-      else
-        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
-      $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      $('<select onchange="filter_types.type.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      for (let i=0; i<this.operators.length; i++)
-        $(`<option value="${this.operators[i]}">${this.operators[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-operator`);
-      for (let i=0; i<this.types.length; i++)
-        $(`<option value="${this.types[i]}">${this.types[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-value`);
-    },
-    apply: function(operator1, type1, operator2, type2, relation) {
-      if (typeof relation == 'undefined'){
-        $.fn.dataTable.ext.search.push(
-          function(settings, data, dataIndex){
-            if (operator1 === 'is')
-              return $(settings.row(dataIndex).node()).hasClass(type1);
-            else if (operator1 === 'is not')
-              return !$(settings.row(dataIndex).node()).hasClass(type1);
-          });
-      }
-      else {
-        $.fn.dataTable.ext.search.push(
-          function(settings, data, dataIndex){
-            if (relation === 'and'){
-              if (operator1 === 'is' && operator2 === 'is')
-                return (($(settings.row(dataIndex).node()).hasClass(type1)) && ($(settings.row(dataIndex).node()).hasClass(type2)));
-              else if (operator1 === 'is' && operator2 === 'is not')
-              return (($(settings.row(dataIndex).node()).hasClass(type1)) && (!$(settings.row(dataIndex).node()).hasClass(type2)));
-              else if (operator1 === 'is not' && operator2 === 'is')
-              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) && ($(settings.row(dataIndex).node()).hasClass(type2)));
-              else if (operator1 === 'is not' && operator2 === 'is not')
-              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) && (!$(settings.row(dataIndex).node()).hasClass(type2)));
-            }
-            else if (relation === 'or'){
-              if (operator1 === 'is' && operator2 === 'is')
-                return (($(settings.row(dataIndex).node()).hasClass(type1)) || ($(settings.row(dataIndex).node()).hasClass(type2)));
-              else if (operator1 === 'is' && operator2 === 'is not')
-              return (($(settings.row(dataIndex).node()).hasClass(type1)) || (!$(settings.row(dataIndex).node()).hasClass(type2)));
-              else if (operator1 === 'is not' && operator2 === 'is')
-              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) || ($(settings.row(dataIndex).node()).hasClass(type2)));
-              else if (operator1 === 'is not' && operator2 === 'is not')
-              return ((!$(settings.row(dataIndex).node()).hasClass(type1)) || (!$(settings.row(dataIndex).node()).hasClass(type2)));
-            }
-          }
-        );
-      }
-      tables.forEach((table) => table.draw())
-    } // .apply()
-  }, // .type
-  tool: {
-    name: "Tool",
-    operators: ["is", "is not"],
-    tools: toolnames,
-    value_field_factory: function(id, span_id=0) {
-      span_id = parseInt(span_id)
-      if ($(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).length > 0)
-        $(`li[data-uid=${id}] span[data-uid=${span_id+1}]`).remove()
-      const iter = $(`li[data-uid=${id}] span`).length
-      if (iter === 0)
-        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] .filter-entry-type`)
-      else
-        $(`<span data-uid=${iter}></span>`).insertAfter(`li[data-uid=${id}] span[data-uid=${iter-1}]`)
-      $('<select class="filter-entry-operator"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      $('<select class="filter-entry-value"><option value=""></option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      $('<select onchange="filter_types.tool.value_field_factory(this.parentElement.parentElement.dataset.uid, this.parentElement.dataset.uid)" class="filter-condition"><option value=""></option><option value="and">AND</option><option value="or">OR</option></select>').appendTo(`li[data-uid=${id}] span[data-uid=${iter}]`)
-      for (let i=0; i<this.operators.length; i++)
-        $(`<option value="${this.operators[i]}">${this.operators[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-operator`);
-      for (let i=0; i<this.tools.length; i++)
-        $(`<option value="${this.tools[i]}">${this.tools[i]}</option>`).appendTo(`li[data-uid=${id}] span[data-uid=${iter}] .filter-entry-value`);
-    },
-    apply: function(operator, tool) {
-      for (const table of tables) {
-        table.columns(col_array).visible(true)
-        table.columns(tool_array).every(function () {
-          let column = this
-          if (column.index() !== 0 && column.index() !== 1) {
-            let theadname = column.header().textContent.trim()
-            if (operator === 'is') {
-              if (theadname === tool) {
-                let index = tool_array.indexOf(column.index())
-                tool_array.splice(index, 1)
-                selected_tools.push(column.index())
-              }
-            }
-            else if (operator === 'is not') {
-              if (theadname !== tool) {
-                let index = tool_array.indexOf(column.index())
-                tool_array.splice(index, 1)
-                selected_tools.push(column.index())
-              }
-            }
-          }
-        })
-        table.columns(tool_array).visible(false)
-      }
-    } // .apply()
-  } // .tool
-} // filter_types
-
-function entryChanged(mode, id) {
-  $(`li[data-uid=${id}] span`).remove();
-  filter_types[mode].value_field_factory(id);
-}
-
-function applyFilter() {
-  for (const table of tables) {
-    tool_array = table.columns()[0]
-    tool_array = tool_array.splice(2)
-    table.columns(col_array).every(function () {
-      $.fn.dataTable.ext.search.pop()
     })
-    table.columns(col_array).search("").draw()
-    table.columns(col_array).visible(true)
-    $.fn.dataTable.ext.search.pop()
-    table.draw()
-    $('.filter-remove').show()
-    let applied_filters = []
-    $('.filter-entries').find('li').each(function () {
-      let object = {}
-      object['filter'] = $(this).find('.filter-entry-type').val()
-      if (object['filter'] === 'tool')
-        object['priority'] = 1
-      else
-        object['priority'] = 0
-      $(this).find('span').each(function (index) {
-        let span = {}
-        span['relation'] = $(this).find('.filter-condition').val()
-        span['operator'] = $(this).find('.filter-entry-operator').val()
-        span['value'] = $(this).find('.filter-entry-value').val()
-        object[index] = span
-      })
-      applied_filters.push(object)
+  }
+  tool_filter.querySelector(".p_invert-selection-button").onclick = (event) => {
+    tool_filter_checkboxes.forEach((element) => {
+      element.checked = !(element.checked)
+      element.dispatchEvent(new Event("change"))
     })
-    applied_filters.sort((a, b) => (a.priority < b.priority) ? 1 : -1)
-    for (const key in applied_filters) {
-      if (applied_filters[key]['filter'] === 'tool')
-        tool_relation = applied_filters[key][0]['relation']
-      if (applied_filters[key]['filter'] !== 'tool' && (Object.keys(applied_filters[key]).length - 2 === 2))
-        filter_types[applied_filters[key]['filter']].apply(applied_filters[key][0]['operator'], applied_filters[key][0]['value'], applied_filters[key][1]['operator'], applied_filters[key][1]['value'], applied_filters[key][0]['relation'])
-      else {
-        for (let i = 0; i < Object.keys(applied_filters[key]).length - 2; i++)
-          filter_types[applied_filters[key]['filter']].apply(applied_filters[key][i]['operator'], applied_filters[key][i]['value'])
-      }
-    }
   }
-}
 
-function removeAll() {
-  $.fn.dataTable.ext.search.pop()
-  for (const table of tables) {
-    table.columns(col_array).search("").draw()
-    table.columns(col_array).visible(true)
-    table.draw()
-  }
-  $('li').remove();
-  $('.filter-apply').hide();
-  $('.filter-remove').hide();
-}
+  const tool_filter_controls = new CheckboxGroupController(filter_state, "tool_filter", tool_filter_checkboxes)
 
-function removeEntry(parent, col_array) {
-  parent.remove();
-  iter = $('.filter-entries').children('li').length;
-  applyFilter();
-  if (iter === 0){
-    $('.filter-apply').hide();
-    $('.filter-remove').hide();
-    $.fn.dataTable.ext.search.pop()
-    for (const table of tables) {
-      table.columns(col_array).search("").draw()
-      table.columns(col_array).visible(true)
-      table.draw()
-    }
-  }
-}
+  // Coverage filter
 
-function addOptions() {
-  iter = $('.filter-entries').children('li').length;
-  if(iter === 0)
-    $('.filter-apply').show();
-  const filter_entries = $(`<li data-uid=${iter}></li>`).appendTo('.filter-entries');
-  const filter_entry_type =  $('<select class="filter-entry-type" onchange="entryChanged(this.value, this.parentElement.dataset.uid)"><option value=""></option></select>').appendTo(filter_entries)
-  $('<i class="fas fa-minus-circle filter-clear" onclick="removeEntry(this.parentElement, col_array)"></i>').insertAfter(filter_entry_type);
+  const coverage_filter_controls = new CoverageFilterEntriesController(filter_state, filter_section.querySelector(".p_coverage-filter"));
 
-  for (const key in filter_types){
-    filter_entry_type.append(`<option value=${key}>${filter_types[key].name}</option>`);
-  }
-  iter = iter + 1;
-}
+  // Type filter
+
+  const type_filter_checkboxes = document.querySelectorAll("#filter-section .p_type-filter input[type='checkbox']")
+  const type_filter_controls = new CheckboxGroupController(filter_state, "type_filter", type_filter_checkboxes)
+})

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -1,33 +1,51 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <style>
-    .log { font-family: "Courier New", Consolas, monospace; font-size: 80%; }
-    .test-failed { background-color: #ffaaaa; }
-    .test-passed { background-color: #aaffaa; }
-  </style>
-</head>
-<body>
-<h3><a href="{{log['runner_url']}}" target="_blank">{{log['runner']|e}}</a></h3>
-<pre class="{{result.status}}">
-description: {{log['description']|e}}
-rc: {{result.exit_code}} (means success: {{log['tool_success']|e}})
-{% if should_fail_because|length %}
-should_fail_because: {{log['should_fail_because']|e}}
-{% endif %}
-tags: {{result.tags|join(' ')|e}}
-incdirs: {{log['incdirs']|e}}
-top_module: {{log['top_module']|e}}
-type: {{result.types|join(' ')|e}}
-mode: {{log['mode']|e}}
-files:{% for f, f_html in input_files_map.items() %} <a href="{{f_html}}" target="file-frame">{{f|e}}</a>{% endfor +%}
-defines: {{log['defines']|e}}
-completed: {{log['date_completed']|e}}
-time_elapsed: {{'%0.3f'| format(result.total_time|float)}}s
-ram usage: {{'%d'| format(result.ram_usage|int)}} KB
-</pre>
-<pre class="log">
-{{content}}
-</pre>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" type="text/css" href="{{csspath}}">
+  </head>
+  <body>
+    <header>
+      <a href="{{log['runner_url']}}" target="_blank"><h1>{{log['runner']|e}}</h1></a>
+      <h2>{{result.name|e}}</h2>
+    </header>
+    <section class="property-list {{result.status}}">
+      <dl>
+        <div><dt>description</dt><dd>{{log['description']|e}}</dd></div>
+        <div><dt>rc</dt><dd>{{result.exit_code}} (means success: {{log['tool_success']|e}})</dd></div>
+        {% if should_fail_because|length %}
+        <div><dt>should_fail_because</dt><dd> {{log['should_fail_because']|e}}</dd></div>
+        {% endif %}
+        <div><dt>tags</dt><dd>{{result.tags|join(' ')|e}}</dd></div>
+        <div>
+          <dt>incdirs</dt>
+          <dd><ul>
+            {% for dir in log['incdirs'].split(' ') %}
+            <li>{{dir}}<li>
+            {% endfor %}
+          </ul></dd>
+        </div>
+        <div><dt>top module</dt><dd>{{log['top_module']|e}}</dd></div>
+        <div><dt>type</dt><dd>{{result.types|join(' ')|e}}</dd></div>
+        <div><dt>mode</dt><dd>{{log['mode']|e}}</dd></div>
+        <div>
+          <dt>files</dt>
+          <dd><ul>
+            {% for f, f_html in input_files_map.items() %}
+            <li><a href="{{f_html}}" target="file-frame">{{f|e}}</a><li>
+            {% endfor %}
+          </ul></dd>
+        </div>
+        <div><dt>defines</dt><dd><code>{{log['defines']|e}}</code></dd></div>
+        <div><dt>completed</dt><dd>{{log['date_completed']|e}}</dd></div>
+        <div><dt>time elapsed</dt><dd>{{'%0.3f'| format(result.total_time|float)}}s</dd></div>
+        <div><dt>ram usage</dt><dd>{{'%d'| format(result.ram_usage|int)}} KB</dd></div>
+      </dl>
+    </section>
+    <section class="log">
+      {% for line in content.split('\n') %}
+      <pre>{{line}}</pre>
+      {% endfor %}
+    </section>
+  </body>
 </html>

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -27,6 +27,7 @@
         </div>
         <div><dt>top module</dt><dd>{{log['top_module']|e}}</dd></div>
         <div><dt>type</dt><dd>{{result.types|join(' ')|e}}</dd></div>
+        <div><dt>results group</dt><dd>{% if result.results_group|length %}{{result.results_group|e}}{% else %}<em></em>{% endif %}</dd></div>
         <div><dt>mode</dt><dd>{{log['mode']|e}}</dd></div>
         <div>
           <dt>files</dt>

--- a/conf/report/log.css
+++ b/conf/report/log.css
@@ -1,0 +1,56 @@
+@import 'details-view.css';
+
+section {
+  margin: 0;
+  padding: 4px;
+  overflow: hidden;
+  width: 100%;
+}
+
+section.property-list.test-passed { background-color: #aaffaa; }
+section.property-list.test-failed { background-color: #ffaaaa; }
+
+section.property-list a:link {
+  color: #00006f;
+}
+
+section.property-list > dl {
+  margin: 0;
+}
+
+section.property-list > dl > div {
+  display: block;
+  line-height: 1.2em;
+}
+
+section.property-list > dl dt {
+  display: inline;
+  font-weight: bold;
+}
+section.property-list > dl dt::after {
+  content: ":";
+}
+
+section.property-list > dl dd {
+  margin: 0 0 0 0.5em;
+  display: inline;
+}
+
+section.property-list > dl dd ul {
+  margin: 0 0 0.5rem 1rem;
+  padding: 0;
+}
+
+section.property-list > dl dd ul li {
+  list-style-type: none;
+}
+
+section.log {
+  padding: 4px;
+}
+
+section.log > pre {
+  margin: 0;
+  padding: 0;
+  font-family: "Courier New", Consolas, monospace;
+}

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -11,7 +11,6 @@
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.19/css/jquery.dataTables.css">
     <script type="text/javascript" charset="utf8" src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" rel="stylesheet"/>
 
     {# Global parameters for scripts and stylesheets #}
     <script>
@@ -30,16 +29,67 @@
     </header>
     <main>
       <section id="filter-section">
-        <button onclick="toggleFilters()">Show advanced filters (experimental)</button>
-        <section style="display: none;" id="filter">
-          <ul class="filter-entries">
-          </ul>
-          <div>
-            <button class="filter-add" onclick="addOptions()">Add</button>
-            <button class="filter-apply" onclick="applyFilter()">Apply</button>
-            <button class="filter-remove" onclick="removeAll()">Remove all filters</button>
-          </div>
-        </section>
+        <details>
+          <summary>
+            Advanced filters
+          </summary>
+          <button id="filter-apply-button" class="v_link-button" disabled>Apply</button>
+          <button id="filter-reset-button" class="v_link-button" disabled>Reset</button>
+          <span id="filter-error-msg"></span>
+          <dl class="c_filter">
+            <dt>Tool</dt>
+            <dd class="p_tool-filter">
+              <div class="p_checkboxes">
+                {% for tool, tool_info in report.tools|numeric_dictsort %}
+                <label title="{{tool|escape_attr}}"><input type="checkbox" value="{{tool|lower|escape_attr}}" checked>{{tool|e}}</label>
+                {% endfor %}
+              </div>
+              <div class="p_buttons-bar">
+                <button class="p_select-all-button">Select all</button>
+                <button class="p_invert-selection-button">Invert selection</button>
+              </div>
+            </dd>
+            <dt>Coverage</dt>
+            <dd class="p_coverage-filter">
+              <div class="p_entry">
+                <select class="p_entry-operator">
+                  <option value="&gt;=">&gt;=</option>
+                  <option value="&lt;=">&lt;=</option>
+                  <option value="&gt;">&gt;</option>
+                  <option value="&lt;">&lt;</option>
+                  <option value="==">==</option>
+                </select>
+                <input type="number" min="0" max="100" class="p_entry-value" value="0"><span>%</span>
+              </div>
+              <template class="p_entry-template">
+                <div class="p_entry v_removable">
+                  <select class="p_entry-relation">
+                    <option value="&amp;&amp;">and</option>
+                    <option value="||">or</option>
+                  </select>
+                  <select class="p_entry-operator">
+                  <option value="&gt;=">&gt;=</option>
+                  <option value="&lt;=">&lt;=</option>
+                  <option value="&gt;">&gt;</option>
+                  <option value="&lt;">&lt;</option>
+                  <option value="==">==</option>
+                  </select>
+                  <input type="number" min="0" max="100" class="p_entry-value" value="0"><span>%</span>
+                  <button class="v_link-button p_remove-entry-button">(remove)</button>
+                </div>
+              </template>
+              <button class="p_add-entry-button">Add condition</button>
+            </dd>
+            <dt>Type</dt>
+            <dd class="p_type-filter">
+              <div class="p_checkboxes">
+                {% for type in ["Elaboration", "Parsing", "Simulation"] %}
+                <label title="{{type|escape_attr}}"><input type="checkbox" value="{{type|lower|escape_attr}}" checked>{{type|e}}</label>
+                {% endfor %}
+              </div>
+            </dd>
+          </dl>
+        </details>
       </section>
       {% for group, group_data in report.groups|numeric_dictsort %}
       <table id="report_table-{{group}}" class="dataTable" data-group="{{group}}">
@@ -65,7 +115,7 @@
           {%       endif %}
           {%     endfor %}
           {%   endfor %}
-          <tr class="{{types_used_in_the_row|join(' ')}}" data-tag="{{tag|e}}">
+          <tr data-types="{{types_used_in_the_row|join(' ')}}" data-tag="{{tag|e}}">
             <th title="{{tag_info.description|escape_attr}}">
               {%- if tag_info.url -%}
               <a class="tag_link" target="_blank" href="{{tag_info.url}}">{{tag_info.description|e}}</a>

--- a/conf/report/report-template.html
+++ b/conf/report/report-template.html
@@ -15,8 +15,7 @@
 
     {# Global parameters for scripts and stylesheets #}
     <script>
-      var TOOL_NAMES = [{{report.tools.keys()|sort|map('escape_js_str')|map('quote')|join(', ')}}];
-      var TOOLS_COUNT = {{report.tools|length}};
+      var TOOL_NAMES = [{{report.tools.keys()|numeric_sort|map('escape_js_str')|map('quote')|join(', ')}}];
     </script>
     <style>:root { --TOOLS_COUNT: {{report.tools|length}}; }</style>
 
@@ -42,29 +41,29 @@
           </div>
         </section>
       </section>
-      <table id="report_table" class="dataTable">
+      {% for group, group_data in report.groups|numeric_dictsort %}
+      <table id="report_table-{{group}}" class="dataTable" data-group="{{group}}">
         <thead>
           <tr>
+            <th><h2>{{group|group_id_to_display_name|e}}</h2></th>
             <th></th>
-            <th></th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            <th title="{{tool_results.version|escape_attr}}" style="--z: {{loop.length - loop.index}}">
-              <a class="tool_link" target="_blank" href="{{tool_results.url}}">{{tool|e}}</a>
+            {% for tool, tool_info in report.tools|numeric_dictsort %}
+            <th title="{{tool_info.version|escape_attr}}" style="--z: {{loop.length - loop.index}}">
+              <a class="tool_link" target="_blank" href="{{tool_info.url}}">{{tool|e}}</a>
             </th>
             {% endfor %}
           </tr>
         </thead>
         <tbody>
-          {% for tag, tag_info in report.tags|dictsort %}
+          {% for tag, tools in group_data.tags_tools|tag_dictsort %}
+          {%   set tag_info = report.tags[tag] %}
           {%   set types_used_in_the_row = [] %}
-          {%   for tool, tool_results in report.tools|dictsort %}
-          {%     if tag in tool_results.tags %}
-          {%       for type in tool_results.tags[tag].types %}
-          {%         if type not in types_used_in_the_row %}
-          {%           set _ = types_used_in_the_row.append(type) %}
-          {%         endif %}
-          {%       endfor %}
-          {%     endif %}
+          {%   for tool, tool_data in tools.items() %}
+          {%     for type in tool_data.types %}
+          {%       if type not in types_used_in_the_row %}
+          {%         set _ = types_used_in_the_row.append(type) %}
+          {%       endif %}
+          {%     endfor %}
           {%   endfor %}
           <tr class="{{types_used_in_the_row|join(' ')}}" data-tag="{{tag|e}}">
             <th title="{{tag_info.description|escape_attr}}">
@@ -74,23 +73,23 @@
               {{tag_info.description|e}}
               {%- endif -%}
             </th>
-            <th title="{{tag_info.description|escape_attr}}">{{tag|lower|e}}</th>
-            {% for tool, tool_results in report.tools|dictsort %}
+            <th title="{{tag_info.description|escape_attr}}">{{tag|e}}</th>
+            {% for tool in report.tools|numeric_sort %}
             {%   set attrs = [] %}
-            {%   if tag in tool_results.tags %}
-            {%     set tag_results = tool_results.tags[tag] %}
-            {%     set test_status = tag_results.status|string %}
+            {%   if tool in tools %}
+            {%     set tool_data = tools[tool] %}
+            {%     set test_status = tool_data.status|string %}
             {%     if test_status != 'test-na' %}
             {%       set _ = attrs.append('class=' ~ (test_status|quote)) %}
             {%       set _ = attrs.append('data-tool=' ~ (tool|lower|escape_attr|quote)) %}
             {%       if test_status == 'test-varied' %}
-            {%         set percentage = '%0.0f'|format(100.0 * tag_results.passed_tests / tag_results.tests|length) %}
+            {%         set percentage = '%0.0f'|format(100.0 * tool_data.passed_tests / tool_data.total_tests) %}
             {%         set _ = attrs.append('style="--val: '~(percentage)~'%"') %}
             {%       endif %}
             {%     endif %}
             {%   endif %}
             {%   if attrs|length %}
-            <td {{attrs|join(' ')}}>{{tag_results.passed_tests}}/{{tag_results.tests|length}}</td>
+            <td {{attrs|join(' ')}}>{{tool_data.passed_tests}}/{{tool_data.total_tests}}</td>
             {%   else %}
             <td></td>
             {%   endif %}
@@ -101,59 +100,95 @@
         <tfoot>
           <tr>
             <th colspan="2">Total tests passed</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            {%   set passed_tests = tool_results.total_passed_tests %}
-            {%   set total_tests = tool_results.total_tests %}
-            {%   set passed_tests_percentage = '%0.0f'|format(100.0 * passed_tests / total_tests) %}
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            {%     set passed_tests = tool_summary.total_passed_tests %}
+            {%     set total_tests = tool_summary.total_tests %}
+            {%     set passed_tests_percentage = '%0.0f'|format(100.0 * passed_tests / total_tests) %}
             <td class="test-varied" style="--val: {{passed_tests_percentage}}%" title="{{tool|lower|e}} ({{passed_tests_percentage}}%)">{{passed_tests}}/{{total_tests}}</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Total tags passed</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            {%   set passed_tags = tool_results.total_passed_tags %}
-            {%   set tested_tags = tool_results.total_tested_tags %}
-            {%   set passed_tags_percentage = '%0.0f'|format(100.0 * passed_tags / tested_tags) %}
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            {%     set passed_tags = tool_summary.total_passed_tags %}
+            {%     set tested_tags = tool_summary.total_tested_tags %}
+            {%     set passed_tags_percentage = '%0.0f'|format(100.0 * passed_tags / tested_tags) %}
             <td class="test-varied" style="--val: {{passed_tags_percentage}}%" title="{{tool|lower|e}} ({{passed_tags_percentage}}%)">{{passed_tags}}/{{tested_tags}}</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Total time elapsed</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.total_time)}}s</td>
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_summary.total_time)}}s</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">User time elapsed</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.user_time)}}s</td>
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_summary.user_time)}}s</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">System time elapsed</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.system_time)}}s</td>
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_summary.system_time)}}s</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Maximum ram usage</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.max_ram_usage)}} MB</td>
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_summary.max_ram_usage)}} MB</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
           <tr>
             <th colspan="2">Average throughput passed for inputs &gt; 1KiB</th>
-            {% for tool, tool_results in report.tools|dictsort %}
-            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_results.passed_throughput|float)}} KiB/s</td>
+            {% for tool in report.tools|numeric_sort %}
+            {%   if tool in group_data.summaries %}
+            {%     set tool_summary = group_data.summaries[tool] %}
+            <td title="{{tool|lower|e}}">{{'%0.0f'|format(tool_summary.passed_throughput|float)}} KiB/s</td>
+            {%   else %}
+            <td></td>
+            {%   endif %}
             {% endfor %}
           </tr>
         </tfoot>
       </table>
+      {% endfor %}
       <section id="summary-section">
         <a href="report.csv">Download a summary in csv</a>
       </section>
     </main>
-    <footer id="footer">
+    <footer>
       <p>
         Generated using <a href="https://github.com/chipsalliance/sv-tests">sv-tests</a>,
         revision: <a href="https://github.com/chipsalliance/sv-tests/commit/{{revision}}">{{revision}}</a>,

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -92,17 +92,6 @@ footer {
   font-size: 10px;
 }
 
-
-/** Filter ************************************************************/
-
-.filter-apply, .filter-remove {
-  display: none;
-}
-
-#filter i {
-  color: #ff6961;
-}
-
 /** Table *************************************************************/
 
 /** Layout **/
@@ -320,6 +309,177 @@ table.dataTable > thead > tr > th:first-of-type h2 {
   overflow: hidden;
   text-overflow: ellipsis;
   color:#666;
+}
+
+/** Filter ************************************************************/
+
+/** Expandable view (<details>) **/
+
+#filter-section > details {
+  position: relative;
+  margin: 0.5rem 0;
+  padding: 0.5rem 0;
+  display: block;
+}
+
+#filter-section > details > summary {
+  display: inline-block;
+  width: fit-content;
+
+  color: black;
+  margin: 0.5rem 0;
+
+  font-size: 1rem;
+  font-weight: bold;
+  text-decoration: underline;
+  text-underline-position: under;
+  text-decoration-color: #00000060;
+  cursor: default;
+}
+#filter-section > details > summary:hover {
+  color: #00006f;
+  text-decoration-color: #00006f80;
+}
+#filter-section > details[open] > summary {
+  margin-right : 1rem;
+}
+#filter-section > details > button {
+  font-weight: bold;
+  display: inline-block;
+  margin-right : 1rem;
+}
+#filter-error-msg {
+  display: inline-block;
+  font-size: 0.8em;
+  font-weight: bold;
+  color: #af1a00;
+}
+#filter-error-msg:empty {
+  display: none;
+}
+
+#filter-section > details[open]::before,
+#filter-section > details[open]::after {
+  content: "";
+  position: absolute;
+  display: block;
+  height: 2px;
+  left: 0;
+  right: 0;
+  background-color: #505050;
+  box-shadow: -1rem 0 #505050, 64px 0 #505050;
+}
+#filter-section > details[open]::before { top: 0.5rem; }
+#filter-section > details[open]::after { bottom: 0.5rem; }
+
+/** Filter controls **/
+
+.c_filter {
+  display: grid;
+  grid-template-columns: 4em 1fr;
+  gap: 1rem 2px;
+  align-items: start;
+  justify-items: stretch;
+  margin: 1rem 0;
+  line-height: 1.5rem;
+}
+
+.c_filter > dt::after {
+  content: ":"
+}
+
+.c_filter > dd {
+  display: block;
+}
+
+.c_filter > dd label {
+  word-break: keep-all;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: 1.5rem;
+}
+
+.c_filter > dd label > input[type="checkbox"] {
+  vertical-align: middle;
+}
+
+.c_filter .p_checkboxes {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 10em);
+  align-items: start;
+}
+
+.c_filter .p_buttons-bar {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+.c_filter .p_buttons-bar > :not(:last-child) {
+  margin-right: 2px;
+}
+
+.c_filter > .p_coverage-filter {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  flex-wrap: wrap;
+  margin-bottom: -4px;
+}
+
+.c_filter > .p_coverage-filter > .p_entry {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+
+  margin-right: 1rem;
+}
+.c_filter > .p_coverage-filter > .p_entry > * {
+  margin-bottom: 4px;
+}
+.c_filter > .p_coverage-filter > .p_entry > :not(:last-child) {
+  margin-right: 2px;
+}
+
+.c_filter > .p_coverage-filter > .p_entry > select {
+  width: fit-content;
+}
+.c_filter > .p_coverage-filter > .p_entry > input[type="number"] {
+  width: fit-content;
+  max-width: 5em;
+}
+.c_filter > .p_coverage-filter > .p_entry > input[type="number"]:invalid {
+  outline: 2px solid #ff6961;
+  color: #af1a00;
+}
+
+button.v_link-button {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  font: inherit;
+  font-size: 0.8em;
+  align-self: center;
+  line-height: 1em;
+
+  color: black;
+  text-decoration: underline;
+  text-underline-position: under;
+  text-decoration-color: #00000060;
+}
+
+button.v_link-button:hover {
+  color: #00006f;
+  text-decoration-color: #00006f80;
+}
+
+button.v_link-button:disabled {
+  color: #cfcece;
+  text-decoration-color: #cfcece60;
 }
 
 /** Details panel *****************************************************/

--- a/conf/report/report.css
+++ b/conf/report/report.css
@@ -1,4 +1,16 @@
-:root {
+/*
+Naming convention used in some elements group:
+
+c_* : component. Marks toplevel component element.
+p_* : A "part" of a component.
+v_* : Variant. Additional class that marks a variant of a part, component
+      or element.
+s_* : State of an element.
+
+Names ("*" above) use lower-kebab-case.
+*/
+
+* {
   box-sizing: border-box;
 }
 
@@ -42,8 +54,8 @@ footer {
   position: sticky;
   /* 100vw includes (unknown) scrollbar width. */
   /* Subtract arbitrary margin from the right to cover for it. */
-  width: calc(100vw - 32px);
-  left: 0;
+  width: calc(100vw - 42px);
+  left: 10px;
 
   margin-left: 0 !important;
   margin-right: 0;
@@ -79,6 +91,7 @@ footer {
   text-align: center;
   font-size: 10px;
 }
+
 
 /** Filter ************************************************************/
 
@@ -291,6 +304,24 @@ a.tool_link:hover, a.tag_link:hover {
   text-decoration-color: #00006f80;
 }
 
+table.dataTable > thead > tr > th:first-of-type {
+  text-align: left;
+  vertical-align: bottom;
+  padding: 0 0 4px 10px;
+  overflow: hidden;
+}
+
+table.dataTable > thead > tr > th:first-of-type h2 {
+  padding: 0;
+  margin: 0;
+  font-family: sans-serif;
+  font-size: 2rem;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color:#666;
+}
+
 /** Details panel *****************************************************/
 
 .c_test-details-panel {
@@ -306,8 +337,9 @@ a.tool_link:hover, a.tag_link:hover {
   grid-template-areas:
     "log file"
     "tests-list tests-list";
-  justify-content: stretch;
+  align-items: stretch;
   justify-items: stretch;
+  justify-content: stretch;
 
   overflow-y: hidden;
   overflow-x: hidden;
@@ -348,6 +380,8 @@ a.tool_link:hover, a.tag_link:hover {
   box-sizing: border-box;
 }
 
+.c_test-details-panel > .p_tests-list > button:focus { outline:0; }
+
 .c_test-details-panel .p_close-button {
   background: #cfcece;
   float: right;
@@ -385,5 +419,3 @@ a.tool_link:hover, a.tag_link:hover {
 .ui-corner-all {
   border-radius: 0px;
 }
-
-button:focus {outline:0;}

--- a/tools/runner
+++ b/tools/runner
@@ -113,7 +113,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners"
+    "compatible-runners", "results_group"
 ]
 
 test_params = {}
@@ -158,6 +158,7 @@ try:
             test_params.setdefault('should_fail_because', "")
             test_params.setdefault('defines', "")
             test_params.setdefault('compatible-runners', "all")
+            test_params.setdefault('results_group', "")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(
@@ -220,6 +221,17 @@ for f in test_params['files']:
                 f, args.runner))
 
 test_params['files'] = filtered_files
+
+# Keep it simple to avoid problems with escaping.
+RESULTS_GROUP_PARAM_VALIDATOR_RE = re.compile(r"[a-z0-9_]*")
+if not RESULTS_GROUP_PARAM_VALIDATOR_RE.fullmatch(
+        test_params["results_group"]):
+    group = test_params["results_group"]
+    fixed_group = re.sub("[^a-z0-9_]", "_", group.lower())
+    logger.warning(
+        f"results_group '{group}' does not match pattern '[a-z0-9_]*'. Replacing with '{fixed_group}'."
+    )
+    test_params['results_group'] = fixed_group
 
 try:
     tmp_dir = tempfile.mkdtemp()

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -386,6 +386,8 @@ def renderLogToHTMLFile(
     log_content = convertPathsToRelativeLinks(
         str(markupsafe.escape(log_content)), log_html_dir)
 
+    csspath = os.path.join(out_dir, "log.css")
+    csspath = os.path.relpath(csspath, os.path.dirname(log_html_path))
     os.makedirs(os.path.dirname(log_html_path), exist_ok=True)
     with open(log_html_path, 'w') as f:
         f.write(
@@ -393,7 +395,8 @@ def renderLogToHTMLFile(
                 input_files_map=files_map,
                 result=test_result,
                 log=test_log,
-                content=log_content))
+                content=log_content,
+                csspath=csspath))
 
 
 with open(args.code_template, "r") as templ:

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -29,6 +29,7 @@ import dataclasses
 import enum
 from typing import Dict, Any, List, Set, Iterable
 import json
+import itertools
 
 parser = argparse.ArgumentParser()
 
@@ -108,8 +109,10 @@ elif args.verbose:
 else:
     logger.setLevel(logging.INFO)
 
+# Common paths
 out_dir = os.path.dirname(os.path.abspath(args.out))
 top_dir = os.path.abspath(os.curdir)
+logs_out_dir = os.path.join(out_dir, "logs")
 
 lex = lexers.get_lexer_by_name("systemverilog")
 
@@ -129,12 +132,55 @@ def surroundWithQuotes(value: str, quot='"'):
     return quot + str(value) + quot
 
 
+# NOTE: this works correctly only with numbers shorter than 10 digits
+def numericSortKey(s: str):
+    # prepend all number occurences with the length of the number
+    r = re.sub(r"\d+", lambda m: str(len(m.group(0))) + m.group(0), s).lower()
+    return r
+
+
+def numericSort(l: List[str]):
+    return sorted(l, key=numericSortKey)
+
+
+def numericDictSort(d: Dict[str, Any]):
+    return sorted(d.items(), key=lambda kv: numericSortKey(kv[0]))
+
+
+# Like numericDictSort, but entries starting with a letter are placed before
+# entries starting with a digit.
+def tagDictSort(d: Dict[str, Any]):
+    def tagSortKey(s: str):
+        if len(s) > 0 and s[0].isdigit():
+            return numericSortKey(s)
+        else:
+            return " " + numericSortKey(s)
+
+    return sorted(d.items(), key=lambda kv: tagSortKey(kv[0]))
+
+
+# Maps results_group ID to a name displayed in a report
+RESULTS_GROUP_DISPLAY_NAMES = {
+    "": "",
+    "cores": "Cores",
+}
+
+
+def getResultsGroupDisplayName(group_id):
+    # TODO: read display names from some config
+    return RESULTS_GROUP_DISPLAY_NAMES.get(group_id, "")
+
+
 # Initialize Jinja2 environment with custom filter
 
 jinja2env = jinja2.Environment(trim_blocks=True, lstrip_blocks=True)
 jinja2env.filters["escape_attr"] = escapeXmlAttribute
 jinja2env.filters["escape_js_str"] = escapeJsString
 jinja2env.filters["quote"] = surroundWithQuotes
+jinja2env.filters["numeric_sort"] = numericSort
+jinja2env.filters["numeric_dictsort"] = numericDictSort
+jinja2env.filters["tag_dictsort"] = tagDictSort
+jinja2env.filters["group_id_to_display_name"] = getResultsGroupDisplayName
 
 
 def exists_and_is_newer_than(target: str, sources: List[str]):
@@ -162,25 +208,6 @@ def totalSize(files):
 def criticalError(msg):
     logger.critical(msg)
     sys.exit(1)
-
-
-# class used for sorting "test tabs" in the report
-class TestResultComp(object):
-    def __init__(self, item):
-        self.item = item
-
-    def prepend_nums(self, s):
-        # prepend all number occurences with the length of the number
-        for m in re.findall(r'\d+', s):
-            s = s.replace(m, str(len(m)) + m)
-
-        return s
-
-    def __lt__(self, other):
-        s = self.prepend_nums(self.item.name)
-        o = self.prepend_nums(other.item.name)
-
-        return s < o
 
 
 def readConfig(filename):
@@ -236,6 +263,7 @@ class TestResult:
     name: str = ""
     tags: Set[str] = dataclasses.field(default_factory=set)
     types: Set[str] = dataclasses.field(default_factory=set)
+    results_group: str = ""
     input_files: List[str] = dataclasses.field(default_factory=list)
     # Unit: bytes
     total_input_files_size: int = 0
@@ -255,18 +283,45 @@ class TestResult:
 
 
 @dataclasses.dataclass
-class TagResults:
-    status: TestStatus = TestStatus.NA
-    types: List[str] = dataclasses.field(default_factory=list)
-    passed_tests: int = 0
-    tests: List[TestResult] = dataclasses.field(default_factory=list)
+class TagInfo:
+    description: str = ""
+    url: str = ""
 
 
 @dataclasses.dataclass
-class ToolResults:
-    tests: Dict[str, TestResult] = dataclasses.field(default_factory=dict)
-    tags: Dict[str, TagResults] = dataclasses.field(default_factory=dict)
+class ToolInfo:
+    # Tool name should be used only for display purposes. Always use a key
+    # from `tools` in `ReportResults` (or another dict where tool ID is
+    # the key) as a runner/tool ID.
+    name: str = ""
+    version: str = ""
+    url: str = ""
 
+
+@dataclasses.dataclass
+class TagToolResult:
+    tests: List[TestResult] = dataclasses.field(default_factory=list)
+    types: Set[str] = dataclasses.field(default_factory=set)
+
+    passed_tests: int = 0
+
+    @property
+    def total_tests(self):
+        return len(self.tests)
+
+    @property
+    def status(self) -> TestStatus:
+        if (self.total_tests == 0):
+            return TestStatus.NA
+        elif (self.passed_tests == 0):
+            return TestStatus.FAILED
+        elif (self.passed_tests == self.total_tests):
+            return TestStatus.PASSED
+        return TestStatus.VARIED
+
+
+@dataclasses.dataclass
+class ToolSummary:
     # Unit: seconds
     total_time: float = 0
     user_time: float = 0
@@ -278,32 +333,40 @@ class ToolResults:
     # Unit: KiB/s
     passed_throughput: float = 0
 
-    # Tool name. This should be used only for display purposes. Always use
-    # a key from `tools` in `ReportResults` as a runner/tool ID.
-    name: str = ""
-    version: str = ""
-    url: str = ""
-
     total_passed_tests: int = 0
+    total_tests: int = 0
     total_passed_tags: int = 0
     total_tested_tags: int = 0
 
-    @property
-    def total_tests(self):
-        return len(self.tests)
-
 
 @dataclasses.dataclass
-class TagInfo:
-    description: str = ""
-    url: str = ""
+class GroupData:
+    # key 1 = tag id; key 2 = runner name = runner class name
+    tags_tools: Dict[str, Dict[str, TagToolResult]] = dataclasses.field(
+        default_factory=dict)
+    # key = runner name = runner class name
+    summaries: Dict[str, ToolSummary] = dataclasses.field(default_factory=dict)
+    # key = runner name = runner class name
+    tests: Dict[str,
+                List[TestResult]] = dataclasses.field(default_factory=dict)
+
+
+# GroupData equivalent for data from a single tool
+@dataclasses.dataclass
+class PartialGroupData:
+    # key 1 = tag id
+    tags: Dict[str, TagToolResult] = dataclasses.field(default_factory=dict)
+    summary: ToolSummary = dataclasses.field(default_factory=ToolSummary)
+    tests: List[TestResult] = dataclasses.field(default_factory=list)
 
 
 @dataclasses.dataclass
 class ReportResults:
-    # Results from each runner/tool.
-    # Keys are runner names (i.e. runner class names)
-    tools: Dict[str, ToolResults] = dataclasses.field(default_factory=dict)
+    # Results groups (key = results group id)
+    groups: Dict[str, GroupData] = dataclasses.field(default_factory=dict)
+    # key = runner name = runner class name
+    tools: Dict[str, ToolInfo] = dataclasses.field(default_factory=dict)
+
     # Tags used in the report. Keys are tag IDs.
     tags: Dict[str, TagInfo] = dataclasses.field(default_factory=dict)
 
@@ -439,7 +502,7 @@ def renderTagResultsConfig(
     js_global_variable_name = f"config_loader_data['{tool}/{tag}']"
 
     # Order of values in each entry:
-    # [name, status, log_html_path, first_input_file_html_path]
+    # [group, name, status, log_html_path, first_input_file_html_path]
     config = []
     for test_result in test_results:
         name = test_result.name
@@ -447,7 +510,8 @@ def renderTagResultsConfig(
         log_html_file = test_result.log_html_file
         first_input_html = test_result.input_files[0] + ".html"
         first_input_html = urllib.parse.quote(first_input_html)
-        config.append([name, status, log_html_file, first_input_html])
+        group = test_result.results_group
+        config.append([group, name, status, log_html_file, first_input_html])
 
     js_data = json.dumps(config, separators=(",", ":"))
     code = f"{js_global_variable_name} = {js_data}"
@@ -458,23 +522,21 @@ def renderTagResultsConfig(
 
 
 def collect_logs(runner_name: str):
-    tool_results = ToolResults()
+    @dataclasses.dataclass
+    class LocalPartialGroupData:
+        group: PartialGroupData = dataclasses.field(
+            default_factory=PartialGroupData)
 
-    # Values used to calculate throughput. Totals are collected only for files
-    # with size > minimum_throughput_file_size
-    passed_tests_time = 0.0
-    passed_tests_input_files_size = 0.0
+        # Values used to calculate throughput. Totals are collected only for
+        # files with size > minimum_throughput_file_size
+        passed_tests_time: float = 0.0
+        passed_tests_input_files_size: float = 0.0
+
+    local_groups: Dict[str, LocalPartialGroupData] = {}
+    tool_info: ToolInfo = ToolInfo()
 
     rendered_count = 0
-
-    @dataclasses.dataclass
-    class TagStatuses:
-        passed_count: int = 0
-        present_statuses: Set[TestStatus] = dataclasses.field(
-            default_factory=set)
-        present_types: Set[str] = dataclasses.field(default_factory=set)
-
-    tags_statuses: Dict[str, TagStatuses] = {}
+    tests_count = 0
 
     for log_file in glob(os.path.join(args.logs, runner_name, "**/*.log"),
                          recursive=True):
@@ -493,7 +555,8 @@ def collect_logs(runner_name: str):
             "description", "files", "incdirs", "top_module", "runner",
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
-            "should_fail_because", "defines", "compatible-runners"
+            "should_fail_because", "defines", "compatible-runners",
+            "results_group"
         }
         test_log_data: Dict[str, Any] = {}
         log_content = ""
@@ -537,12 +600,10 @@ def collect_logs(runner_name: str):
 
             log_content = f.read()
 
-        tool_results.tests[t_id] = test_result
-
-        if tool_results.name == "":
-            tool_results.name = test_log_data["runner"]
+        # Test Result
 
         test_result.name = test_log_data["name"]
+        test_result.results_group = test_log_data["results_group"]
 
         # Convert splitted "tags" to set() and append all meta-tags
         test_result.tags = set(test_log_data["tags"].split())
@@ -564,20 +625,13 @@ def collect_logs(runner_name: str):
         tool_should_fail = test_log_data["should_fail"] == "1"
         tool_crashed = test_result.exit_code >= 126
         tool_failed = test_log_data["tool_success"] == "0"
-
         if tool_crashed or tool_should_fail != tool_failed:
             test_result.status = TestStatus.FAILED
-        elif test_log_data["mode"] == "simulation" and not parseLog(
-                log_content):
+        elif (test_log_data["mode"] == "simulation"
+              and not parseLog(log_content)):
             test_result.status = TestStatus.FAILED
         else:
             test_result.status = TestStatus.PASSED
-            tool_results.total_passed_tests += 1
-            # Collect stats for calculating passed_throughput
-            input_files_size = test_result.total_input_files_size
-            if input_files_size > minimum_throughput_file_size:
-                passed_tests_input_files_size += input_files_size
-                passed_tests_time += float(test_log_data["time_elapsed"])
 
         test_result.timeout = int(test_log_data["timeout"])
 
@@ -585,18 +639,9 @@ def collect_logs(runner_name: str):
         test_result.user_time = float(test_log_data["user_time"])
         test_result.system_time = float(test_log_data["system_time"])
 
-        tool_results.total_time += test_result.total_time
-        tool_results.user_time += test_result.user_time
-        tool_results.system_time += test_result.system_time
-
         test_result.ram_usage = float(test_log_data["ram_usage"])  # KB
-        ram_usage_mb = test_result.ram_usage / 1000
-        if tool_results.max_ram_usage < ram_usage_mb:
-            tool_results.max_ram_usage = ram_usage_mb
 
-        logs_out_dir = os.path.join(out_dir, "logs")
         log_html = os.path.join(logs_out_dir, t_id + ".html")
-
         test_result.log_html_file = os.path.relpath(log_html, out_dir)
 
         # Render the log if needed
@@ -605,93 +650,186 @@ def collect_logs(runner_name: str):
             rendered_count += 1
             renderLogToHTMLFile(
                 out_dir, log_html, test_result, test_log_data, log_content)
+        tests_count += 1
+
+        # Group
+
+        local_group = local_groups.setdefault(
+            test_result.results_group, LocalPartialGroupData())
+        group = local_group.group
+        group.tests.append(test_result)
+
+        # (tag, tool) results
 
         for tag in test_result.tags:
-            tag_statuses = tags_statuses.setdefault(tag, TagStatuses())
+            tag_data = group.tags.setdefault(tag, TagToolResult())
+            tag_data.tests.append(test_result)
+            tag_data.types.update(test_result.types)
             if test_result.status == TestStatus.PASSED:
-                tag_statuses.passed_count += 1
-            tag_statuses.present_statuses.add(test_result.status)
-            tag_statuses.present_types.update(test_result.types)
+                tag_data.passed_tests += 1
 
-    for tag, tag_statuses in tags_statuses.items():
-        tag_results = tool_results.tags[tag] = TagResults()
+        # Summary
 
-        tag_results.passed_tests = tag_statuses.passed_count
-        if len(tag_statuses.present_statuses) == 0:
-            tag_results.status = TestStatus.NA
-        elif len(tag_statuses.present_statuses) == 1:
-            tag_results.status = list(tag_statuses.present_statuses)[0]
-            tool_results.total_tested_tags += 1
-            if (tag_results.status == TestStatus.PASSED):
-                tool_results.total_passed_tags += 1
+        if test_result.status == TestStatus.PASSED:
+            input_files_size = test_result.total_input_files_size
+            if input_files_size > minimum_throughput_file_size:
+                local_group.passed_tests_input_files_size += input_files_size
+                local_group.passed_tests_time += test_result.total_time
+
+        summary = group.summary
+
+        summary.total_time += test_result.total_time
+        summary.user_time += test_result.user_time
+        summary.system_time += test_result.system_time
+
+        ram_usage_mb = test_result.ram_usage / 1000
+        if summary.max_ram_usage < ram_usage_mb:
+            summary.max_ram_usage = ram_usage_mb
+
+        summary.total_tests += 1
+        if test_result.status == TestStatus.PASSED:
+            summary.total_passed_tests += 1
+
+        if tool_info.name == "":
+            tool_info.name = test_log_data["runner"]
+
+    logger.info(
+        f"{runner_name}: (Re)generated {rendered_count}/{tests_count} rendered log files."
+    )
+
+    all_used_tags: Set[str] = set()
+
+    for group_id, local_group in local_groups.items():
+        group = local_group.group
+        all_used_tags.update(group.tags.keys())
+        for tag_id, tag_tool_result in group.tags.items():
+            if tag_tool_result.status != TestStatus.NA:
+                group.summary.total_tested_tags += 1
+                if tag_tool_result.status == TestStatus.PASSED:
+                    group.summary.total_passed_tags += 1
+
+            tag_tool_result.tests.sort(key=lambda t: numericSortKey(t.name))
+
+        time = local_group.passed_tests_time
+        size = local_group.passed_tests_input_files_size
+        if time == 0:
+            group.summary.passed_throughput = 0
         else:
-            tag_results.status = TestStatus.VARIED
-            tool_results.total_tested_tags += 1
+            group.summary.passed_throughput = size / time / 1024
 
-        tag_results.types = list(tag_statuses.present_types)
-
-        tag_results.tests = sorted(
-            [t for t in tool_results.tests.values() if tag in t.tags],
-            key=TestResultComp)
-
+    for tag_id in all_used_tags:
+        # List of tag's test lists from all groups
+        tests_lists = [
+            lg.group.tags[tag_id].tests
+            for lg in local_groups.values()
+            if tag_id in lg.group.tags
+        ]
         config_js = os.path.join(
             out_dir, "results", runner_name.lower(),
-            f"{tag.lower()}.config.js")
+            tag_id.lower() + ".config.js")
 
         # Render the config
-        renderTagResultsConfig(config_js, runner_name, tag, tag_results.tests)
+        renderTagResultsConfig(
+            config_js, runner_name, tag_id,
+            itertools.chain.from_iterable(tests_lists))
 
     try:
         with open(os.path.join(args.logs, runner_name, "version")) as f:
-            tool_results.version = f.read().strip()
+            tool_info.version = f.read().strip()
     except IOError:
         pass
 
     try:
         with open(os.path.join(args.logs, runner_name, "url")) as f:
-            tool_results.url = f.read().strip()
+            tool_info.url = f.read().strip()
     except IOError:
         pass
 
-    if passed_tests_time == 0:
-        tool_results.passed_throughput = 0
-    else:
-        tool_results.passed_throughput = (
-            passed_tests_input_files_size / passed_tests_time / 1024)
+    groups: Dict[str, PartialGroupData] = {
+        id: lg.group
+        for id, lg in local_groups.items()
+    }
 
-    logger.info(
-        f"{runner_name}: (Re)generated {rendered_count}/{tool_results.total_tests} rendered log files."
-    )
-
-    return tool_results
+    return {
+        "tool_info": tool_info,
+        "partial_groups": groups,
+    }
 
 
-logger.info("Generating {} from log files in '{}'".format(args.out, args.logs))
+# CamelCase or undscore_separator csv headers ?
+# We use CamelCase so that gnuplot getting header from CSV displays them
+# as-is and doesn't print the post-underscore letter a subscript.
+csv_header = [
+    'TestName',
+    'Tool',  # Parser/Compiler/Tool processing it
+    'Group',
+    'Pass',  # result. True if we got expected result.
+    'ExitCode',  # Actual tool exit code
+    'Tags',
+    'InputBytes',  # test facts
+    'AllowedTimeout',  # Some measurements
+    'TimeUser',
+    'TimeSystem',
+    'TimeWall',
+    'RamUsageMiB'
+]
+csv_output = {}
 
 # Input files (.sv) path relative to repository's toplevel directory
 all_input_files: Set[str] = set()
 
 runner_names = []
-
 for r in [os.path.dirname(r) for r in glob(args.logs + "/*/")]:
     runner_name = os.path.basename(r)
     logger.debug("Found Runner: " + runner_name)
-
     runner_names.append(runner_name)
+
+logger.info("Generating {} from log files in '{}'".format(args.out, args.logs))
 
 with multiprocessing.Pool() as pool:
     results = pool.map(collect_logs, runner_names)
 
 for tool_name, tool_results in zip(runner_names, results):
-    report_data.tools[tool_name] = tool_results
-    for tag in tool_results.tags:
-        if tag not in database and tag not in report_data.tags:
-            logger.warning("Tag not present in the database: " + tag)
-        report_data.tags.setdefault(
-            tag,
-            TagInfo(description=database.get(tag, ""), url=urls.get(tag, "")))
-    for test_result in tool_results.tests.values():
-        all_input_files.update(test_result.input_files)
+    report_data.tools[tool_name] = tool_results["tool_info"]
+    partial_groups: Dict[str,
+                         PartialGroupData] = tool_results["partial_groups"]
+
+    for group_id, partial_group in partial_groups.items():
+        group = report_data.groups.setdefault(group_id, GroupData())
+        group.tests[tool_name] = partial_group.tests
+        group.summaries[tool_name] = partial_group.summary
+
+        for tag_id, tool_data in partial_group.tags.items():
+            tools = group.tags_tools.setdefault(tag_id, {})
+            tools[tool_name] = tool_data
+
+            if tag_id not in database and tag_id not in report_data.tags:
+                logger.warning("Tag not present in the database: " + tag_id)
+            report_data.tags.setdefault(
+                tag_id,
+                TagInfo(
+                    description=database.get(tag_id, ""),
+                    url=urls.get(tag_id, "")))
+
+        for test_result in partial_group.tests:
+            all_input_files.update(test_result.input_files)
+
+            unique_row = test_result.name + ":" + tool_name
+
+            csv_output[unique_row] = {
+                "TestName": test_result.name,
+                "Tool": tool_name,
+                "Group": test_result.results_group,
+                "Pass": test_result.status == TestStatus.PASSED,
+                "ExitCode": test_result.exit_code,
+                "Tags": " ".join(test_result.tags),
+                "InputBytes": test_result.total_input_files_size,
+                "AllowedTimeout": test_result.timeout,
+                "TimeUser": round(test_result.user_time, 6),
+                "TimeSystem": round(test_result.system_time, 6),
+                "TimeWall": round(test_result.total_time, 6),
+                "RamUsageMiB": round(test_result.ram_usage / 1024, 3),
+            }
 
 # Render input files
 rendered_count = 0
@@ -706,43 +844,6 @@ for input_file in all_input_files:
 logger.info(
     f"(Re)generated {rendered_count}/{len(all_input_files)} rendered input files."
 )
-
-# CamelCase or undscore_separator csv headers ?
-# We use CamelCase so that gnuplot getting header from CSV displays them
-# as-is and doesn't print the post-underscore letter a subscript.
-csv_header = [
-    'TestName',
-    'Tool',  # Parser/Compiler/Tool processing it
-    'Pass',  # result. True if we got expected result.
-    'ExitCode',  # Actual tool exit code
-    'Tags',
-    'InputBytes',  # test facts
-    'AllowedTimeout',  # Some measurements
-    'TimeUser',
-    'TimeSystem',
-    'TimeWall',
-    'RamUsageMiB'
-]
-
-csv_output = {}
-
-for tool_name, tool_results in report_data.tools.items():
-    for test_result in tool_results.tests.values():
-        unique_row = test_result.name + ":" + tool_name
-
-        csv_output[unique_row] = {
-            "TestName": test_result.name,
-            "Tool": tool_name,
-            "Pass": test_result.status == TestStatus.PASSED,
-            "ExitCode": test_result.exit_code,
-            "Tags": " ".join(test_result.tags),
-            "InputBytes": test_result.total_input_files_size,
-            "AllowedTimeout": test_result.timeout,
-            "TimeUser": round(test_result.user_time, 6),
-            "TimeSystem": round(test_result.system_time, 6),
-            "TimeWall": round(test_result.total_time, 6),
-            "RamUsageMiB": round(test_result.ram_usage / 1024, 3),
-        }
 
 try:
     with open(args.template, "r") as f:


### PR DESCRIPTION
The PR implements `results_group` property that can be added to tests. Separate table in the report is generated for each group.
For simplicity, the results group ID can only contain characters `[0-1a-z_]`. To assign nice display name to a group, add an entry to `RESULTS_GROUP_DISPLAY_NAMES` in `tools/sv-report`. By default no name is displayed.
The default group ID (the one assigned to tests without group set) is empty string `""`.

Patch that tags some tests and adds display names for a few groups: https://github.com/antmicro/sv-tests/commit/0bfdf01e4c7d3ecc11a28f6122d6e1d10b5463ac.patch

There are also a few other changes (sorry for "all in one" PR :) ):
* Slightly improved test details panel style
* Faster and better looking sorting. Fractions with the same value are additionally sorted, so that 0/42 < 0/1 < ... 2/6 < 1/3 < ... < 2/3 < 4/6 < ... < 1/1 < 42/42.
* Reimplemented filter. It would be pretty hard to add support for multiple tables to the previous one.


![Screenshot 2021-12-27 at 07-09-53 SystemVerilog Report](https://user-images.githubusercontent.com/4888536/147441956-5bd7c62a-96f3-4963-9d38-65ef7f91cf01.png)

---

![Screenshot 2021-12-27 at 07-20-46 SystemVerilog Report](https://user-images.githubusercontent.com/4888536/147441969-67a8d8cf-3091-4dac-8f22-db950b02881f.png)

---

![Screenshot 2021-12-27 at 07-24-08 moore_parse fx68k fx68k - SystemVerilog Report](https://user-images.githubusercontent.com/4888536/147441977-60dddab0-4596-43fe-b541-e0f0bd264d37.png)
