### PR TITLE
Make use of the results_group

### DIFF
--- a/conf/generators/meta-path/basejump.json
+++ b/conf/generators/meta-path/basejump.json
@@ -48,5 +48,6 @@
 		"bsg_sbox_ctrl_concentrate.v",
 		"bsg_pg_tree.v"
 	],
-	"fake_topmodule": true
+	"fake_topmodule": true,
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/hdlconvertor.json
+++ b/conf/generators/meta-path/hdlconvertor.json
@@ -17,5 +17,6 @@
 		"parity_using_function2.v",
 		"stm_import.sv"
 	],
-	"type": "parsing"
+	"type": "parsing",
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/hdlconvertor_std2012.json
+++ b/conf/generators/meta-path/hdlconvertor_std2012.json
@@ -11,5 +11,6 @@
 		"p140.sv",
 		"p77.sv"
 	],
-	"type": "parsing"
+	"type": "parsing",
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/hdlconvertor_std2017.json
+++ b/conf/generators/meta-path/hdlconvertor_std2017.json
@@ -39,5 +39,6 @@
 		"p886.sv",
 		"p940.sv"
 	],
-	"type": "parsing"
+	"type": "parsing",
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/projf-explore.json
+++ b/conf/generators/meta-path/projf-explore.json
@@ -5,5 +5,6 @@
 		["tests", "projf-explore", "*", "*", "*"]
 	],
 	"matches": ["*.sv"],
-	"type": "parsing"
+	"type": "parsing",
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/utd-systemverilog.json
+++ b/conf/generators/meta-path/utd-systemverilog.json
@@ -6,5 +6,6 @@
 	],
 	"matches": ["*.v"],
 	"blacklist": ["sparc_ffu_ctl_visctl.v", "operators.v", "pad_jbusl.v", "pad_jbusr.v", "fpu_in_ctl.v", "ifdef-2.v"],
-	"type": "parsing"
+	"type": "parsing",
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-asicworld.json
+++ b/conf/generators/meta-path/yosys-asicworld.json
@@ -5,5 +5,6 @@
 		["tools", "yosys", "tests", "asicworld"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["code_verilog_tutorial_counter_tb.v", "code_hdl_models_arbiter_tb.v", "code_verilog_tutorial_first_counter_tb.v", "code_verilog_tutorial_fsm_full_tb.v", "code_hdl_models_full_subtracter_gates.v", "simple_values.v", "svinterface_at_top.sv"]
+	"blacklist": ["code_verilog_tutorial_counter_tb.v", "code_hdl_models_arbiter_tb.v", "code_verilog_tutorial_first_counter_tb.v", "code_verilog_tutorial_fsm_full_tb.v", "code_hdl_models_full_subtracter_gates.v", "simple_values.v", "svinterface_at_top.sv"],
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-errors.json
+++ b/conf/generators/meta-path/yosys-errors.json
@@ -6,5 +6,6 @@
 		["tools", "yosys", "tests", "errors"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["syntax_err06.v", "syntax_err09.v", "syntax_err12.v", "syntax_err13.v"]
+	"blacklist": ["syntax_err06.v", "syntax_err09.v", "syntax_err12.v", "syntax_err13.v"],
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-memories.json
+++ b/conf/generators/meta-path/yosys-memories.json
@@ -5,5 +5,6 @@
 		["tools", "yosys", "tests", "memories"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["issue00335.v"]
+	"blacklist": ["issue00335.v"],
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -5,5 +5,6 @@
 		["tools", "yosys", "tests", "simple"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v", "mem2reg_bounds_tern.v"]
+	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v", "mem2reg_bounds_tern.v"],
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-sva.json
+++ b/conf/generators/meta-path/yosys-sva.json
@@ -5,5 +5,6 @@
 		["tools", "yosys", "tests", "sva"]
 	],
 	"matches": ["*.sv"],
-	"blacklist": ["basic04.sv", "basic05.sv"]
+	"blacklist": ["basic04.sv", "basic05.sv"],
+	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-svinterfaces.json
+++ b/conf/generators/meta-path/yosys-svinterfaces.json
@@ -5,5 +5,6 @@
 		["tools", "yosys", "tests", "svinterfaces"]
 	],
 	"matches": ["*.sv"],
-	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv", "load_and_derive.sv", "ondemand.sv"]
+	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv", "load_and_derive.sv", "ondemand.sv"],
+	"results_group": "imported"
 }

--- a/generators/ariane
+++ b/generators/ariane
@@ -19,6 +19,7 @@ templ = """/*
 :files: {0}
 :incdirs: {1}
 :tags: ariane
+:results_group: cores
 :top_module: {2}
 :timeout: 360
 */

--- a/generators/black-parrot
+++ b/generators/black-parrot
@@ -20,6 +20,7 @@ templ = """/*
 :incdirs: {1}
 :top_module: {2}
 :tags: black-parrot
+:results_group: imported
 :timeout: 1000
 */
 """

--- a/generators/fusesoc
+++ b/generators/fusesoc
@@ -14,6 +14,7 @@ templ = """/*
 :top_module: {5}
 :tags: {6}
 :timeout: {7}
+:results_group: cores
 :compatible-runners: {8}
 :type: {9}
 */

--- a/generators/fx68k
+++ b/generators/fx68k
@@ -17,6 +17,7 @@ templ = """/*
 :description: Full fx68k core test
 :files: {0}
 :tags: fx68k
+:results_group: cores
 :timeout: 100
 */
 """

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -20,6 +20,7 @@ templ = """/*
 :files: {1}
 :incdirs: {3}
 :tags: ivtest
+:results_group: imported
 :type: simulation parsing
 {2}
 {4}

--- a/generators/path_generator
+++ b/generators/path_generator
@@ -56,9 +56,13 @@ for cfg in glob.glob(os.path.join(conf_dir, 'generators', 'meta-path',
         incdirs = data.get('incdirs', [])
         timeouts = data.get('timeouts', {})
         test_type = data.get('type', None)
+        results_group = data.get('results_group', None)
 
         if test_type is not None:
             global_extra_tags.append(f":type: {test_type}")
+
+        if results_group is not None:
+            global_extra_tags.append(f":results_group: {results_group}")
 
         if 'fake_topmodule' in data:
             global_extra_tags.append(":top_module: top")

--- a/generators/rsd
+++ b/generators/rsd
@@ -20,6 +20,7 @@ templ = """/*
 :incdirs: {1}
 :tags: rsd
 :top_module: Core
+:results_group: cores
 :timeout: 100
 */
 """

--- a/generators/scr1
+++ b/generators/scr1
@@ -19,6 +19,7 @@ templ = """/*
 :incdirs: {1}
 :tags: scr1
 :top_module: scr1_top_tb_axi
+:results_group: cores
 :timeout: 100
 */
 """

--- a/generators/tnoc
+++ b/generators/tnoc
@@ -19,6 +19,7 @@ templ = """/*
 :files: {0}
 :tags: TNoC
 :top_module: tnoc
+:results_group: cores
 :timeout: 100
 */
 """

--- a/generators/yosys_hana
+++ b/generators/yosys_hana
@@ -17,6 +17,7 @@ templ = """/*
 :name: {1}
 :description: Tests imported from yosys
 :files: {0}
+:results_group: imported
 :tags: yosys
 */
 """


### PR DESCRIPTION
This uses the feature added in #1959 to sort tests into various result groups.

Most of the tests are still ungroupped.

There are two new groups:
* cores - where we put all big desings/riscv cores
* imported - which contains regression test suites imported from other tools

It might be worth to move all UVM tests to a group of its own too but it's not done here.