### PR TITLE
Fix 11.4.14.3--unpack_stream_inv.sv on Verilator

### DIFF
--- a/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
+++ b/tests/chapter-11/11.4.14.3--unpack_stream_inv.sv
@@ -12,6 +12,7 @@
 :description: invalid stream unpack test
 :should_fail_because: stream is wider than assignment target
 :tags: 11.4.14.3
+:runner_verilator_flags: -Werror-WIDTH
 :type: simulation elaboration
 */
 module top();


### PR DESCRIPTION
On Verilator the generic Verilator tool harness disables this warning due to noise in other tests, so this specific test needs to re-enable it.