### PR TITLE
Add orderedmultidict to pip dependencies

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -10,3 +10,4 @@ markupsafe
 pytablewriter
 GitPython
 git+https://github.com/lowRISC/fusesoc.git@ot
+orderedmultidict


### PR DESCRIPTION
This is a dependency of Surelog/UHDM packages.
See: https://github.com/chipsalliance/UHDM/issues/602

At the moment we don't have a way to install python dependencies to
individual tools, but this is a small package so let's install it
globally.