### PR TITLE
Remove uvm tag from earlgrey

### DIFF
--- a/conf/fusesoc-configs/earlgrey.yml
+++ b/conf/fusesoc-configs/earlgrey.yml
@@ -10,7 +10,7 @@
 name: earlgrey
 description: Earlgrey design from opentitan
 top_module: top_earlgrey_nexysvideo
-tags: earlgrey uvm
+tags: earlgrey
 path: third_party/cores/opentitan
 command: fusesoc --cores-root third_party/cores/opentitan run --target=sim lowrisc:systems:top_earlgrey:0.1
 conf_file: build/lowrisc_systems_top_earlgrey_0.1/sim-icarus/lowrisc_systems_top_earlgrey_0.1.scr


### PR DESCRIPTION
This creates a new UVM row in the Cores tab which is misleading and looks like a bug.

CC @hzeller 