### PR TITLE
Build moore from a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -89,3 +89,6 @@
 [submodule "third_party/tools/verilator-uhdm"]
 	path = third_party/tools/verilator-uhdm
 	url = https://github.com/antmicro/verilator
+[submodule "third_party/tools/moore"]
+	path = third_party/tools/moore
+	url = https://github.com/fabianschuiki/moore.git

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -130,7 +130,7 @@ $(INSTALL_DIR)/bin/parse_sv:
 moore: $(INSTALL_DIR)/bin/moore
 
 $(INSTALL_DIR)/bin/moore:
-	cargo install --git "https://github.com/fabianschuiki/moore" --root $(INSTALL_DIR) --bin moore
+	cargo install --path $(RDIR)/moore --root $(INSTALL_DIR) --bin moore
 
 # verible
 verible:


### PR DESCRIPTION
Currently we always try to install latest moore. This way we cannot really track/control the version. Current version breaks the CI at the moment.