### PR TITLE
Increase timeout for long ivtests

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -279,7 +279,7 @@ for l in ivtest_lists:
 
             timeout = ''
             if name in ivtest_long:
-                timeout = ':timeout: 30'
+                timeout = ':timeout: 360'
 
             tests.append(
                 (


### PR DESCRIPTION
30s is still too small timeout value for Surelog to parse long ivtests. Locally it takes about 60s to parse them, so here I increase timeout to 360s.
Fixes: https://github.com/antmicro/yosys-uhdm-plugin-integration/issues/361
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>