### PR TITLE
Add 'elaboration' mode back to ivtests

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -21,7 +21,7 @@ templ = """/*
 :incdirs: {3}
 :tags: ivtest
 :results_group: imported
-:type: simulation parsing
+:type: simulation elaboration parsing
 {2}
 {4}
 */


### PR DESCRIPTION
This was recently changed from elaboration to simulation but that's not really correct; the tests don't really require simulation, but they do need elaboration in order for a bunch of them to pass -- most of the ones that are marked as should_fail require semantic analysis, not just parsing. Without setting elaboration, tools will fail to correctly fail on those tests.

Signed-off-by: MikePopoloski <mike@popoloski.com>