### PR TITLE
Change swerv-lint to swerv-sim.

### DIFF
--- a/conf/fusesoc-configs/swerv-sim.yml
+++ b/conf/fusesoc-configs/swerv-sim.yml
@@ -12,9 +12,9 @@ description: Full swerv core test
 top_module: swerv_wrapper
 tags: swerv
 path: third_party/cores/swerv
-command: fusesoc --cores-root third_party/cores/swerv run --target=lint chipsalliance.org:cores:SweRV_EH1:1.8
-conf_file: build/chipsalliance.org_cores_SweRV_EH1_1.8/lint-verilator/chipsalliance.org_cores_SweRV_EH1_1.8.vc
-test_file: swerv.sv
+command: fusesoc --cores-root third_party/cores/swerv run --target=sim chipsalliance.org:cores:SweRV_EH1:1.8
+conf_file: build/chipsalliance.org_cores_SweRV_EH1_1.8/sim-verilator/chipsalliance.org_cores_SweRV_EH1_1.8.vc
+test_file: swerv-sim.sv
 timeout: 180
 compatible-runners: verilator-uhdm verilator slang
 type: parsing elaboration


### PR DESCRIPTION
Simulation mode should be enabled when it will be possible to generate simulation binary without run it automatically. 