### PR TITLE
Improve github cache handling

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -117,6 +117,8 @@ jobs:
           format: 'YYYY-MM-DD-HH-mm-ss'
       - name: Setup cache
         uses: actions/cache@v2
+        timeout-minutes: 3
+        continue-on-error: true
         with:
           path: "/root/sv-tests/sv-tests/.cache/"
           key: cache_${{ matrix.tool.name }}_${{ steps.cache_timestamp.outputs.time }}


### PR DESCRIPTION
Github caches tend to get buggy with GCP runners that we use here.
If they work correctly, the caches are set up in ~45s max.
If they don't, this steps tends to take over 360 minutes (the default
timeout) and break the CI.

This patch tries to workaround this problem by setting the timeout to 3
minutes but making the cache step optional. If we fail to set up caches,
just build everything normally, it will be quicker anyway.