### PR TITLE
history graph: properly interpret date in data points

### DIFF
--- a/conf/report/history-graph-template.html
+++ b/conf/report/history-graph-template.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@3.5.0/dist/chart.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@2.0.0/dist/chartjs-adapter-date-fns.bundle.min.js"></script>
 </head>
 
 <body>
@@ -55,6 +56,7 @@
         scales: {
           x: {
             display: true,
+            type: 'time',
             title: {
               display: true,
               text: 'Date of the build'


### PR DESCRIPTION
There are days where there are fewer or more builds that 1 a day. Each
build generates a new entry in the history graph.

Without this change, each entry created a new evenly separated data
point which didn't really make sense when analyzing the history.

With this change the data points will be split in accordance to the
actual build timestamp.

As a side benefit we have a nicer formatting of the dates.
Full timestamps can still be checked by hovering individual data points.

Before:
![2022-02-04-144009](https://user-images.githubusercontent.com/8438531/152539217-7d2510fe-8c42-429a-9ccc-e9bf09104959.png)
After:
![2022-02-04-144028](https://user-images.githubusercontent.com/8438531/152539235-2de403aa-6bb6-4d8f-b765-14f178308d28.png)
