### PR TITLE
Checkout only tests and cores in summary

### DIFF
--- a/.github/workflows/report.sh
+++ b/.github/workflows/report.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Add local submodules
-git submodule update --init --recursive
-
 make $@ generate-tests
 cp -ar ./out/report_*/logs ./out/
 make $@ report

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -191,6 +191,12 @@ jobs:
       - name: Extract
         run: |
           for file in $(find out/ -name *.tar -print); do tar -xf $file --strip-components=2 -C $(dirname $file); done
+      - name: Checkout third party tests and cores
+        run: |
+          git submodule update --init --recursive third_party/tests
+          git submodule update --init --recursive third_party/cores
+          # yosys tool also contains tests
+          git submodule update --init --recursive third_party/tools/yosys
       - name: Summary
         run: |
           ./.github/workflows/summary.sh


### PR DESCRIPTION
This PR speeds up summary job by checking out only tests and cores instead of every submodule (including tools).
Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>