### PR TITLE
Fix duplicate sources added to Ariane build

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -74,7 +74,7 @@ for components in ver_cmd_comp:
         # isn't instantiated anywhere. Problematically, it contains references to a
         # nonexistent interface, so it otherwise breaks elaboration. This hack can be
         # removed if the problem gets fixed upstream.
-        if 'axi2apb_wrap.sv' not in args:
+        if 'axi2apb_wrap.sv' not in args and args not in sources:
             sources += os.path.join(ariane_path, args) + ' '
 
 os.chdir(main_path)


### PR DESCRIPTION
The Ariane source list contains duplicate entries for some source files, which causes most tools to throw up errors about duplicated definitions. This diff filters out the duplicates to fix that.