### PR TITLE
Specify top module when parsing UHDM

### DIFF
--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -86,6 +86,9 @@ class UhdmVerilator(BaseRunner):
                 'surelog -nopython -nobuiltin -parse -sverilog -nonote -noinfo -nowarning'
             )
 
+            if top is not None:
+                f.write(f' --top-module {top}')
+
             # lowmem option
             if "black-parrot" in params["tags"]:
                 f.write(' -lowmem')

--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -55,6 +55,9 @@ class UhdmYosys(BaseRunner):
                 f"surelog -nopython -nobuiltin -parse -sverilog -nonote -noinfo -nowarning -DSYNTHESIS"
             )
 
+            if top is not None:
+                f.write(f' --top-module {top}')
+
             # lowmem option
             if "black-parrot" in params["tags"]:
                 f.write(' -lowmem')

--- a/tools/runners/VanillaYosysUhdmPlugin.py
+++ b/tools/runners/VanillaYosysUhdmPlugin.py
@@ -55,6 +55,9 @@ class VanillaYosysUhdmPlugin(BaseRunner):
                 f"surelog -nopython -nobuiltin -parse -sverilog -nonote -noinfo -nowarning -DSYNTHESIS"
             )
 
+            if top is not None:
+                f.write(f' --top-module {top}')
+
             # lowmem option
             if "black-parrot" in params["tags"]:
                 f.write(' -lowmem')


### PR DESCRIPTION
To obtain valid UHDM we need to specify the top module to be used (or at least our best guess).