### PR TITLE
Add slang-parse runner

### DIFF
--- a/conf/fusesoc-configs/earlgrey-synth.yml
+++ b/conf/fusesoc-configs/earlgrey-synth.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/opentitan run --flag=fileset_top
 conf_file: build/lowrisc_systems_chip_earlgrey_nexysvideo_0.1/synth-vivado/lowrisc_systems_chip_earlgrey_nexysvideo_0.1.tcl
 test_file: earlgrey-synth.sv
 timeout: 360
-compatible-runners: yosys-uhdm vanilla-yosys-uhdm-plugin yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog
+compatible-runners: yosys-uhdm vanilla-yosys-uhdm-plugin yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse
 type: parsing elaboration

--- a/conf/fusesoc-configs/ibex-synth.yml
+++ b/conf/fusesoc-configs/ibex-synth.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/ibex run --target=synth --setup 
 conf_file: build/lowrisc_ibex_top_artya7_0.1/synth-vivado/lowrisc_ibex_top_artya7_0.1.tcl
 test_file: ibex-synth.sv
 timeout: 100
-compatible-runners: yosys-uhdm vanilla-yosys-uhdm-plugin yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog
+compatible-runners: yosys-uhdm vanilla-yosys-uhdm-plugin yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse
 type: parsing elaboration

--- a/conf/fusesoc-configs/swerv-synth.yml
+++ b/conf/fusesoc-configs/swerv-synth.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/swerv run --target=synth --setup
 conf_file: build/swerv_synth/synth-vivado/chipsalliance.org_cores_SweRV_EH1_1.8.tcl
 test_file: swerv-synth.sv
 timeout: 180
-compatible-runners: yosys-uhdm vanilla-yosys-uhdm-plugin yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog
+compatible-runners: yosys-uhdm vanilla-yosys-uhdm-plugin yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse
 type: parsing elaboration

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -13,10 +13,12 @@ from BaseRunner import BaseRunner
 
 
 class Slang(BaseRunner):
-    def __init__(self):
+    def __init__(
+            self,
+            name="slang",
+            supported_features={'preprocessing', 'parsing', 'elaboration'}):
         super().__init__(
-            "slang", "slang-driver",
-            {'preprocessing', 'parsing', 'elaboration'})
+            name, executable="slang-driver", supported_features=supported_features)
 
         self.url = "https://github.com/MikePopoloski/slang"
 
@@ -57,7 +59,7 @@ class Slang(BaseRunner):
         # black-parrot has syntax errors where variables are used before they are declared.
         # This is being fixed upstream, but it might take a long time to make it to master
         # so this works around the problem in the meantime.
-        if "black-parrot" in tags:
+        if "black-parrot" in tags and mode != "parsing":
             self.cmd.append("--allow-use-before-declare")
 
             # These tests simply cannot be elaborated because they target

--- a/tools/runners/Slang_parse.py
+++ b/tools/runners/Slang_parse.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+from runners.Slang import Slang
+
+
+class Slang_parse(Slang):
+    def __init__(self):
+        super().__init__("slang-parse", supported_features={'preprocessing', 'parsing'})


### PR DESCRIPTION
Many of the tools in the sv-tests report are parsers -- slang can be run as a standalone parser so it'd be nice to compare slang's performance and correctness with these other parser tools, similarly to the moore_parse runner.