### PR TITLE
Support paths surrounded by {} in .tcl files

### DIFF
--- a/generators/fusesoc
+++ b/generators/fusesoc
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import re
 import sys
 import yaml
 import subprocess
@@ -121,10 +122,11 @@ for fusesoc_conf_file in fusesoc_conf_files:
         with open(core_conf_path, "r") as f:
             for line in f:
                 line = line.strip()
-                if line.startswith("read_verilog -sv "):
-                    sources += os.path.join(
-                        sources_path, line.replace("read_verilog -sv ",
-                                                   "")) + " "
+                src_file_match = re.match(
+                    r"read_verilog\s+-sv\s+{?(.+?)}?\s*$", line)
+                if src_file_match:
+                    src_file = src_file_match.group(1)
+                    sources += os.path.join(sources_path, src_file) + " "
                 elif line.startswith("set_property include_dirs "):
                     line.replace("set_property include_dirs ", "")
                     # Skip unnecessary information here, leave only paths to include dirs


### PR DESCRIPTION
File names in .tcl files sometimes are surrounded with `{}`:
```
read_verilog -sv {../src/chipsalliance.org_cores_SweRV_EH1_1.8/design/dec/dec_tlu_ctl.sv}
```

This should fix failing CI.