### PR TITLE
UhdmYosys: do not use lowmem for Surelog

### DIFF
--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -43,13 +43,6 @@ class UhdmYosys(BaseRunner):
             if top is not None:
                 f.write(f' --top-module {top}')
 
-            # lowmem option
-            if "black-parrot" in params["tags"]:
-                f.write(' -lowmem')
-
-            if "earlgrey" in params["tags"]:
-                f.write(' -lowmem')
-
             if mode in ["parsing", "preprocessing"]:
                 f.write(' -noelab')
 


### PR DESCRIPTION
When using `-lowmem` with Surelog used as library it doesn't work as surelog tries to run argv[0] as a new command (to call itself) which in our case calls yosys directly.

This might lead to OOM errors instead though