### PR TITLE
Remove ibex-yosys-build from runners build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -68,9 +68,6 @@
 [submodule "third_party/tests/uvm"]
 	path = third_party/tests/uvm
 	url = https://github.com/SymbiFlow/uvm.git
-[submodule "third_party/cores/ibex-yosys-build"]
-	path = third_party/cores/ibex-yosys-build
-	url = https://github.com/SymbiFlow/ibex-yosys-build.git
 [submodule "third_party/cores/tnoc"]
 	path = third_party/cores/tnoc
 	url = https://github.com/taichi-ishitani/tnoc.git

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -28,13 +28,6 @@ yosys: $(INSTALL_DIR)/bin/yosys
 $(INSTALL_DIR)/bin/yosys:
 	$(MAKE) -C $(RDIR)/yosys PREFIX=$(INSTALL_DIR) install
 
-# antmicro-yosys
-antmicro-yosys: $(INSTALL_DIR)/bin/antmicro-yosys
-
-$(INSTALL_DIR)/bin/antmicro-yosys:
-	$(MAKE) -C $(RDIR)/../cores/ibex-yosys-build/yosys ENABLE_TCL=0 ENABLE_ABC=0 ENABLE_GLOB=0 ENABLE_PLUGINS=0 ENABLE_READLINE=0 ENABLE_COVER=0
-	install -D $(RDIR)/../cores/ibex-yosys-build/yosys/yosys $@
-
 # icarus
 icarus: $(INSTALL_DIR)/bin/iverilog
 
@@ -129,6 +122,6 @@ $(INSTALL_DIR)/bin/verible-verilog-kythe-extractor: verible
 $(INSTALL_DIR)/bin/verilog_syntax: verible
 
 # setup the dependencies
-RUNNERS_TARGETS := odin yosys icarus verilator slang zachjs-sv2v tree-sitter-verilog sv-parser moore verible surelog antmicro-yosys yosys-uhdm vanilla-yosys-uhdm-plugin verilator-uhdm
+RUNNERS_TARGETS := odin yosys icarus verilator slang zachjs-sv2v tree-sitter-verilog sv-parser moore verible surelog yosys-uhdm vanilla-yosys-uhdm-plugin verilator-uhdm
 .PHONY: $(RUNNERS_TARGETS)
 runners: $(RUNNERS_TARGETS)


### PR DESCRIPTION
The antmicro-yosys does not build anymore with current compilers,
is not updated anymore and also not run in the tests anymore.

Signed-off-by: Henner Zeller <h.zeller@acm.org>