### PR TITLE
Fix basic syntax errors in 12.6.1 tests

### DIFF
--- a/tests/chapter-12/12.6.1--case_pattern.sv
+++ b/tests/chapter-12/12.6.1--case_pattern.sv
@@ -28,7 +28,7 @@ module case_tb ();
 
 	u tmp;
 
-	initial case (v) matches
+	initial case (tmp) matches
 		tagged a '{.v, 0} : $display("a %d", v);
 		tagged a '{.v1, .v2} : $display("a %d %d", v1, v2);
 		tagged b '{.v1, .v2} : $display("b %d %d", v1, v2);

--- a/tests/chapter-12/12.6.1--casex_pattern.sv
+++ b/tests/chapter-12/12.6.1--casex_pattern.sv
@@ -28,7 +28,7 @@ module case_tb ();
 
 	u tmp;
 
-	initial casex (v) matches
+	initial casex (tmp) matches
 		tagged a '{.v, 4'b00?x} : $display("a %d", v);
 		tagged a '{.v1, .v2} : $display("a %d %d", v1, v2);
 		tagged b '{.v1, .v2} : $display("b %d %d", v1, v2);

--- a/tests/chapter-12/12.6.1--casez_pattern.sv
+++ b/tests/chapter-12/12.6.1--casez_pattern.sv
@@ -28,7 +28,7 @@ module case_tb ();
 
 	u tmp;
 
-	initial casez (v) matches
+	initial casez (tmp) matches
 		tagged a '{.v, 4'bzz0?} : $display("a %d", v);
 		tagged a '{.v1, .v2} : $display("a %d %d", v1, v2);
 		tagged b '{.v1, .v2} : $display("b %d %d", v1, v2);


### PR DESCRIPTION
The tests have the wrong variable name in the case expressions.