### PR TITLE
Fix class_test_52.sv to be legal

### DIFF
--- a/tests/generic/class/class_test_52.sv
+++ b/tests/generic/class/class_test_52.sv
@@ -16,7 +16,6 @@ class uvm_sequence_item;
 endclass
 class how_wide #(type DT=int) extends uvm_sequence_item;
   localparam Max_int = {$bits(DT) - 1{1'b1}};
-  localparam Min_int = {$bits(int) - $bits(DT){1'b1}};
 endclass
 
 module test;


### PR DESCRIPTION
IEEE 11.4.12.1 disallows zero size replication in the removed line.