### PR TITLE
runners: icarus: Fix top-level module specification

### DIFF
--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -27,7 +27,7 @@ class Icarus(BaseRunner):
         self.cmd += ["-o", ofile]
 
         if params['top_module'] != '':
-            self.cmd.append('-s ' + params['top_module'])
+            self.cmd += ['-s', params['top_module']]
 
         for incdir in params['incdirs']:
             self.cmd.append('-I' + incdir)


### PR DESCRIPTION
Currently when specifying a top-level module for the icarus runner the `-s` switch is passed together with the top-level module name as a single parameter. Both are separated by a space, e.g. `-s top`. This results in the space being included in the top-level module name, resulting in errors such as

    error: Unable to find the root module " top" in the Verilog source.

Pass to the `-s` switch and the top-level module name as two separate parameters to fix this.