### PR TITLE
Use older bazel

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -31,7 +31,7 @@ jobs:
           - name: tree-sitter-verilog
             deps: npm
           - name: verible
-            deps: bazel bison flex libfl-dev
+            deps: bazel=5.4.0 bison flex libfl-dev
             skip-ccache: 1
           - name: verilator
             deps: autoconf autotools-dev bison flex libfl-dev libelf-dev


### PR DESCRIPTION
There is an issue with platform detection in bazel 6.0.0

Until this is fixed in Verible, use an older bazel version.