### PR TITLE
runners: icarus: Support all modes

### DIFF
--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -15,16 +15,25 @@ import os
 
 class Icarus(BaseRunner):
     def __init__(self):
-        super().__init__("icarus", "iverilog", {"parsing"})
+        super().__init__(
+            'icarus', 'iverilog', {
+                'preprocessing', 'parsing', 'elaboration', 'simulation',
+                'simulation_without_run'
+            })
 
         self.url = "http://iverilog.icarus.com/"
 
     def prepare_run_cb(self, tmp_dir, params):
         ofile = 'iverilog.out'
 
-        self.cmd = [self.executable, "-g2012"]
+        self.cmd = [self.executable, '-g2012']
 
-        self.cmd += ["-o", ofile]
+        self.cmd += ['-o', ofile]
+
+        if params['mode'] == 'preprocessing':
+            self.cmd.append('-E')
+        elif params['mode'] == 'parsing':
+            self.cmd += ['-t', 'null']
 
         if params['top_module'] != '':
             self.cmd += ['-s', params['top_module']]
@@ -36,6 +45,17 @@ class Icarus(BaseRunner):
             self.cmd.append('-D' + define)
 
         self.cmd += params['files']
+
+        if params['mode'] != 'simulation':
+            return
+
+        # For simulation a wrapper script is created
+        scr = os.path.join(tmp_dir, 'scr.sh')
+        with open(scr, 'w') as f:
+            f.write('set -x\n')
+            f.write('{0} "$@" || exit $?\n'.format(self.cmd[0]))
+            f.write(f'./iverilog.out\n')
+        self.cmd = ['sh', 'scr.sh'] + self.cmd[1:]
 
     def get_version_cmd(self):
         return [self.executable, "-V"]


### PR DESCRIPTION
The icarus runner at the moment only supports parsing mode. Add support for the other modes as well.

 * For `preprocessing` the `-E` flag is added in which case only the preprocessor is being executed.
 * For `parsing` mode now the `null` backend is used to skip the code generation phase.
 * For `elaboration` nothing special has to be done since it is the default behavior
 * To support `simulation` a shell script is created that first executes the iverilog compiler and then if that is successful executes the resulting executable. This is similar to what other runners do.