### PR TITLE
Temporarily use older ubuntu image

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -10,7 +10,7 @@ jobs:
   Comment:
     name: Comment
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:jammy-20221130
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Install dependencies

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -56,7 +56,7 @@ jobs:
 
     name: ${{ matrix.tool.name }}
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:jammy-20221130
     steps:
       - name: Cancel previous
         uses: styfle/cancel-workflow-action@0.8.0
@@ -155,7 +155,7 @@ jobs:
   Summary:
     name: Summary
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:jammy-20221130
     needs: Run
     env:
       ANALYZER: "$PWD/tools/report_analyzer.py"

--- a/.github/workflows/trigger-lint.yml
+++ b/.github/workflows/trigger-lint.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   upload_event_file:
     runs-on: [self-hosted, Linux, X64]
-    container: ubuntu:latest
+    container: ubuntu:jammy-20221130
     steps:
       - uses: actions/checkout@v2
       - name: Copy event file


### PR DESCRIPTION
Latest points to jammy, this does not change the distro, but takes an older Jammy release.

The new one seems to not be compatible with Singularity (which we're using in our custom runners).

This change can be reverted once the Singularity issue is resolved. Alternatively we can switch to other distro (debian seems to work).

Signed-off-by: Tomasz Gorochowik <tgorochowik@antmicro.com>