### PR TITLE
Add help2man for Verilator and update Verilator

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -34,9 +34,9 @@ jobs:
             deps: bazel=5.4.0 bison flex libfl-dev
             skip-ccache: 1
           - name: verilator
-            deps: autoconf autotools-dev bison flex libfl-dev libelf-dev
+            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev
           - name: verilator-uhdm
-            deps: autoconf autotools-dev bison default-jre flex libfl-dev cmake pkg-config tclsh uuid-dev libelf-dev
+            deps: autoconf autotools-dev bison default-jre flex help2man libfl-dev cmake pkg-config tclsh uuid-dev libelf-dev
             runners_filter: UhdmVerilator
           - name: yosys
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev


### PR DESCRIPTION
This fixes the build error that was preventing dependabot from being able to upgrade Verilator.  It also does the Verilator update.