### PR TITLE
Blacklist two invalid yosys tests

### DIFF
--- a/conf/generators/meta-path/yosys-simple.json
+++ b/conf/generators/meta-path/yosys-simple.json
@@ -5,6 +5,6 @@
 		["tools", "yosys", "tests", "simple"]
 	],
 	"matches": ["*.v"],
-	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v", "mem2reg_bounds_tern.v"],
+	"blacklist": ["hierdefparam.v", "memory.v", "values.v", "func_width_scope.v", "named_genblk.v", "mem2reg_bounds_tern.v", "module_scope_func.v"],
 	"results_group": "imported"
 }

--- a/conf/generators/meta-path/yosys-svinterfaces.json
+++ b/conf/generators/meta-path/yosys-svinterfaces.json
@@ -5,6 +5,6 @@
 		["tools", "yosys", "tests", "svinterfaces"]
 	],
 	"matches": ["*.sv"],
-	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv", "load_and_derive.sv", "ondemand.sv"],
+	"blacklist": ["svinterface1.sv", "svinterface_at_top.sv", "load_and_derive.sv", "ondemand.sv", "resolve_types.sv"],
 	"results_group": "imported"
 }


### PR DESCRIPTION
* module_scope_func - Uses a function declared inside a generate block as a constant expression, which is pretty straightforwardly not allowed by the LRM
* resolve_types - Has multiple problems: references an undeclared module, and uses a keyword as the name of a module.