### PR TITLE
Add sticky headers to log and detail panels

### DIFF
--- a/conf/report/code-template.html
+++ b/conf/report/code-template.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="stylesheet" type="text/css" href="{{csspath}}">
   </head>
-  <body>
-    <header><h2>{{filename|e}}</h2></header>
+  <body>  
+    <header id="header_code"><h2>{{filename|e}}</h2></header>  
     {{ code }}
   </body>
 </html>

--- a/conf/report/code.css
+++ b/conf/report/code.css
@@ -70,6 +70,13 @@ pre {
   margin: 0;
 }
 
+#header_code {
+  position:sticky;
+  left: 0;
+  top: 0;
+  width: calc(100vw - 13px);
+}
+
 .linenodiv a {
   color: #000000;
   text-decoration: none;

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -5,11 +5,11 @@
     <link rel="stylesheet" type="text/css" href="{{csspath}}">
   </head>
   <body>
-    <header>
-      <a href="{{log['runner_url']}}" target="_blank"><h1>{{log['runner']|e}}</h1></a>
-      <h2>{{result.name|e}}</h2>
+    <header id="header_log" class="{{result.status}} sticky-y">
+        <a href="{{log['runner_url']}}" target="_blank"><h1>{{log['runner']|e}}</h1></a>
+        <h2>{{result.name|e}}</h2>
     </header>
-    <section class="property-list {{result.status}}">
+    <section class="property-list">
       <dl>
         <div><dt>description</dt><dd>{{log['description']|e}}</dd></div>
         <div><dt>rc</dt><dd>{{result.exit_code}} (means success: {{log['tool_success']|e}})</dd></div>

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -5,7 +5,7 @@
     <link rel="stylesheet" type="text/css" href="{{csspath}}">
   </head>
   <body>
-    <header id="header_log" class="{{result.status}} sticky-y">
+    <header class="{{result.status}}">
         <a href="{{log['runner_url']}}" target="_blank"><h1>{{log['runner']|e}}</h1></a>
         <h2>{{result.name|e}}</h2>
     </header>
@@ -48,5 +48,6 @@
       <pre>{{line}}</pre>
       {% endfor %}
     </section>
+  </div>
   </body>
 </html>

--- a/conf/report/log-template.html
+++ b/conf/report/log-template.html
@@ -48,6 +48,5 @@
       <pre>{{line}}</pre>
       {% endfor %}
     </section>
-  </div>
   </body>
 </html>

--- a/conf/report/log.css
+++ b/conf/report/log.css
@@ -46,13 +46,17 @@ section.property-list > dl > div {
 header.test-passed {
   background-color: var(--green);
   position: sticky;
+  left: 0;
   top: 0;
+  width: calc(100vw - 15px);
 }
 
 header.test-failed {
   background-color: var(--red);
   position: sticky;
+  left: 0;
   top: 0;
+  width: calc(100vw - 15px);
 }
 
 section.property-list > dl dt {
@@ -87,3 +91,5 @@ section.log > pre {
   padding: 0;
   font-family: "Courier New", Consolas, monospace;
 }
+
+


### PR DESCRIPTION
- added sticky (y and x axis) headers to log and code windows
- the background color of the log header instead of the list of properties now shows whether it is passed or not 