### PR TITLE
Update 6.23--type_op_compare.sv

### DIFF
--- a/tests/chapter-6/6.23--type_op_compare.sv
+++ b/tests/chapter-6/6.23--type_op_compare.sv
@@ -15,7 +15,7 @@
 module top #( parameter type T = type(logic[11:0]) )
    ();
    initial begin
-      case (type(T))
+      case (type(T)
         type(logic[11:0]) : ;
         default           : $stop;
       endcase


### PR DESCRIPTION
Fix syntax error : extra ')'.

To be note :
- some tool does not notice the syntax error
- the syntax error is present in text example Ieee1685-2017 page 131
![image](https://user-images.githubusercontent.com/1123617/226092102-6b1300ab-b529-4a64-aabf-a2fa45343b7b.png)
