### PR TITLE
CI: don't initialize submodules recursively; update actions version

### DIFF
--- a/.github/workflows/sv-tests-code-quality.yml
+++ b/.github/workflows/sv-tests-code-quality.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.7
       - name: Script
@@ -25,9 +25,6 @@ jobs:
       - name: Test
         run:
           test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }
-      - name: Clone submodules
-        run:
-          git submodule update --init --recursive
       - name: License
         uses: SymbiFlow/actions/checks@main
         with:


### PR DESCRIPTION
``SymbiFlow/actions/checks`` action only looks at top directory in ``third_party`` folder (e.g. it doesn't check recursively for ``LICENSE`` file in submodules of submodule): https://github.com/f4pga/actions/blob/main/checks/checks.py#L380.

This PR removes initialization of submodules recursively and also updates ``actions/checkout`` and  ``actions/setup-python`` version to newest stable. This reduces CI job time from ``29m 57s`` to ``2m 20s``.