### PR TITLE
Fix moore build in CI

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -17,7 +17,7 @@ jobs:
           - name: icarus
             deps: autoconf autotools-dev bison flex libfl-dev gperf
           - name: moore
-            rust_ver: 1.59
+            rust_ver: "1.60"
           - name: odin
             repo: odin_ii
             deps: autoconf autotools-dev bison flex libfl-dev cmake pkg-config


### PR DESCRIPTION
Moore build is currently broken in CI since one of its dependencies requires rust 1.60, but the CI only install rust 1.59.

Bump the rust version for the CI to 1.60 to fix this.