### PR TITLE
Fix two misc test issues

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -270,6 +270,8 @@ ivtest_file_exclude = [
     'pr2794144',
     # Specified --top-module 'top' was not found in design (sv-test driver limitation)
     'vlg_pr1587634_iv',
+    # primitive table rows are invalid, fails on multiple commercial tools
+    "pr3587570",
 ]
 
 ivtest_long = ['comp1000', 'comp1001']

--- a/generators/rsd
+++ b/generators/rsd
@@ -81,3 +81,4 @@ with open(test_file, "w") as f:
     f.write(templ.format(sources, incdirs))
     f.write("`define RSD_SYNTHESIS\n")
     f.write("`define RSD_SYNTHESIS_DESIGN_COMPILER\n")
+    f.write("`define RSD_MARCH_FP_PIPE\n")


### PR DESCRIPTION
* RSD core appears to need RSD_MARCH_FP_PIPE macro defined, otherwise tools that actually do error checking will tell you:
```
../../../third_party/cores/rsd/Processor/Src/FloatingPointUnit/FPDivSqrtUnit.sv:9:76: error: 'FPDivSqrtUnit' is not a modport of 'RecoveryManagerIF'
module FPDivSqrtUnit(FPDivSqrtUnitIF.FPDivSqrtUnit port, RecoveryManagerIF.FPDivSqrtUnit recovery);
                                                                           ^~~~~~~~~~~~~
```

* One ivtest entry has invalid table rows defined for a primitive, confirmed failure on commercial tools:
```
../../../third_party/tests/ivtest/ivltests/pr3587570.v:8:6: error: primitive table row has all 'x' inputs so its output must also be 'x'
     ? : 0;
     ^~~~~~
../../../third_party/tests/ivtest/ivltests/pr3587570.v:8:6: error: primitive table row duplicates a set of inputs with a different specified output value
     ? : 0;
     ^~~~~~
../../../third_party/tests/ivtest/ivltests/pr3587570.v:6:6: note: previous definition here
     1 : 1;
     ^~~~~~
```