### PR TITLE
Unfreeze tree sitter

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
-tree_sitter==0.2.2
+tree_sitter
 pygments
 yapf==0.30.0
 psutil


### PR DESCRIPTION
The version we used was pretty old, there were lots of changes in tree sitter verilog which hopefully allow us to use the latest py tree sitter.

Ref: #4549 