### PR TITLE
Avoid race conditions between `assign` and `initial`

### DIFF
--- a/conf/generators/templates/assignment-sim.json
+++ b/conf/generators/templates/assignment-sim.json
@@ -12,7 +12,7 @@
 		"reg [31:0] a;",
 		"wire [31:0] b;",
 		"assign b = 32'd{3};",
-		"initial begin",
+		"final begin",
 		"    a = 32'd{2};",
 		"    a {0}= b;",
 		"    $display(\":assert: (int(%s) == %d)\", \"{2}{0}{3}\", a);",

--- a/conf/generators/templates/equality.json
+++ b/conf/generators/templates/equality.json
@@ -15,7 +15,7 @@
 		"assign a = {0};",
 		"assign b = {1};",
 		"assign c = a {2} b;",
-		"initial begin",
+		"final begin",
 		"    $display(\":assert: ('%s' == '%d')\", \"{3}\", c);",
 		"end",
 		"endmodule"

--- a/conf/generators/templates/logical-equiv.json
+++ b/conf/generators/templates/logical-equiv.json
@@ -15,7 +15,7 @@
 		"assign a = {0};",
 		"assign b = {1};",
 		"assign c = a <-> b;",
-		"initial begin",
+		"final begin",
 		"    $display(\":assert: ((%s) == %d)\", \"(((not {0}) or {1}) and ((not {1}) or {0}))\", c);",
 		"end",
 		"endmodule"

--- a/conf/generators/templates/logical-impl.json
+++ b/conf/generators/templates/logical-impl.json
@@ -15,7 +15,7 @@
 		"assign a = {0};",
 		"assign b = {1};",
 		"assign c = a -> b;",
-		"initial begin",
+		"final begin",
 		"    $display(\":assert: ((%s) == %d)\", \"((not {0}) or {1})\", c);",
 		"end",
 		"endmodule"

--- a/conf/generators/templates/logical.json
+++ b/conf/generators/templates/logical.json
@@ -15,7 +15,7 @@
 		"assign a = {0};",
 		"assign b = {1};",
 		"assign c = a {2} b;",
-		"initial begin",
+		"final begin",
 		"    $display(\":assert: ((%s) == %d)\", \"{0} {3} {1}\", c);",
 		"end",
 		"endmodule"

--- a/conf/generators/templates/operators-sim.json
+++ b/conf/generators/templates/operators-sim.json
@@ -15,7 +15,7 @@
 		"assign a = 32'd{3};",
 		"assign b = 32'd{4};",
 		"assign c = a {0} b;",
-		"initial begin",
+		"final begin",
 		"    $display(\":assert: (int(%s) == %d)\", \"{3}{0}{4}\", c);",
 		"end",
 		"endmodule"


### PR DESCRIPTION
The initial execution of a `assign` statement is scheduled in the same time slot as an `initial` block.

There are a few tests that use an `initial` block to evaluate whether an `assign` statement was correctly executed. But this leads to an inherit race condition as the `initial` block might run before the `assign` has been executed.

Switch these tests to use a `final` block instead to avoid the race condition.