### PR TITLE
Refer to specific commits in GitHub links

### DIFF
--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -57,6 +57,7 @@ class BaseRunner:
         self.allowed_extensions = ['.v', '.sv', '.vh', '.svh']
 
         self.url = "https://github.com/symbiflow/sv-tests"
+        self.submodule = ""
 
     def get_mode(self, test_features, compatible_runners):
         """Determine correct run mode or return None when incompatible
@@ -202,6 +203,28 @@ class BaseRunner:
             return log.decode('utf-8')
         except (TypeError, NameError, OSError):
             return self.name
+
+    def get_commit(self):
+        """Attempt to get the commit hash of the tool. The result is based on
+        the latest commit of its corresponding sumbodule.
+
+        Returns a hash string
+        """
+
+        try:
+            cmd = ["git", "rev-parse", "HEAD:" + self.submodule]
+
+            proc = subprocess.Popen(
+                cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+            log, _ = proc.communicate()
+
+            if proc.returncode != 0:
+                return "HEAD"
+
+            return log.decode('utf-8').strip()
+        except (TypeError, NameError, OSError):
+            return "HEAD"
 
     def get_url(self):
         """Get the URL to the homepage of the runner

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -212,7 +212,11 @@ class BaseRunner:
         """
 
         try:
-            cmd = ["git", "rev-parse", "HEAD:" + self.submodule]
+            path = "HEAD"
+            if self.submodule:
+                path += ":" + self.submodule
+
+            cmd = ["git", "rev-parse", path]
 
             proc = subprocess.Popen(
                 cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -21,7 +21,8 @@ class Icarus(BaseRunner):
                 'simulation_without_run'
             })
 
-        self.url = "http://iverilog.icarus.com/"
+        self.submodule = "third_party/tools/icarus"
+        self.url = f"https://github.com/steveicarus/iverilog/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         ofile = 'iverilog.out'

--- a/tools/runners/Odin.py
+++ b/tools/runners/Odin.py
@@ -16,7 +16,8 @@ class Odin(BaseRunner):
     def __init__(self):
         super().__init__("odin", "odin_II", {"preprocessing", "parsing"})
 
-        self.url = "https://verilogtorouting.org/"
+        self.submodule = "third_party/tools/odin_ii"
+        self.url = f"https://github.com/verilog-to-routing/vtr-verilog-to-routing/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
 

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -22,7 +22,9 @@ class Slang(BaseRunner):
             executable="slang-driver",
             supported_features=supported_features)
 
-        self.url = "https://github.com/MikePopoloski/slang"
+        self.submodule = "third_party/tools/slang"
+        commit = self.get_commit()
+        self.url = "https://github.com/MikePopoloski/slang/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         mode = params['mode']

--- a/tools/runners/Slang.py
+++ b/tools/runners/Slang.py
@@ -23,8 +23,7 @@ class Slang(BaseRunner):
             supported_features=supported_features)
 
         self.submodule = "third_party/tools/slang"
-        commit = self.get_commit()
-        self.url = "https://github.com/MikePopoloski/slang/tree/" + commit
+        self.url = f"https://github.com/MikePopoloski/slang/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         mode = params['mode']

--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -18,8 +18,7 @@ class Surelog(BaseRunner):
         super().__init__("Surelog", "surelog")
 
         self.submodule = "third_party/tools/Surelog"
-        commit = self.get_commit()
-        self.url = "https://github.com/chipsalliance/Surelog/tree/" + commit
+        self.url = f"https://github.com/chipsalliance/Surelog/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable, '-nopython', '-parse']

--- a/tools/runners/Surelog.py
+++ b/tools/runners/Surelog.py
@@ -17,7 +17,9 @@ class Surelog(BaseRunner):
     def __init__(self):
         super().__init__("Surelog", "surelog")
 
-        self.url = "https://github.com/chipsalliance/Surelog"
+        self.submodule = "third_party/tools/Surelog"
+        commit = self.get_commit()
+        self.url = "https://github.com/chipsalliance/Surelog/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable, '-nopython', '-parse']

--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -18,7 +18,9 @@ class Sv2v_zachjs(BaseRunner):
             "zachjs-sv2v", "zachjs-sv2v",
             {"preprocessing", "parsing", "elaboration"})
 
-        self.url = "https://github.com/zachjs/sv2v"
+        self.submodule = "third_party/tools/zachjs-sv2v"
+        commit = self.get_commit()
+        self.url = "https://github.com/zachjs/sv2v/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/Sv2v_zachjs.py
+++ b/tools/runners/Sv2v_zachjs.py
@@ -19,8 +19,7 @@ class Sv2v_zachjs(BaseRunner):
             {"preprocessing", "parsing", "elaboration"})
 
         self.submodule = "third_party/tools/zachjs-sv2v"
-        commit = self.get_commit()
-        self.url = "https://github.com/zachjs/sv2v/tree/" + commit
+        self.url = f"https://github.com/zachjs/sv2v/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -27,8 +27,7 @@ class UhdmVerilator(BaseRunner):
         self.c_extensions = ['.cc', '.c', '.cpp', '.h', '.hpp']
         self.allowed_extensions.extend(['.vlt'] + self.c_extensions)
         self.submodule = "third_party/tools/verilator-uhdm"
-        commit = self.get_commit()
-        self.url = "https://github.com/antmicro/verilator/tree/" + commit
+        self.url = f"https://github.com/antmicro/verilator/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         mode = params['mode']

--- a/tools/runners/UhdmVerilator.py
+++ b/tools/runners/UhdmVerilator.py
@@ -26,7 +26,9 @@ class UhdmVerilator(BaseRunner):
 
         self.c_extensions = ['.cc', '.c', '.cpp', '.h', '.hpp']
         self.allowed_extensions.extend(['.vlt'] + self.c_extensions)
-        self.url = "https://github.com/antmicro/verilator"
+        self.submodule = "third_party/tools/verilator-uhdm"
+        commit = self.get_commit()
+        self.url = "https://github.com/antmicro/verilator/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         mode = params['mode']

--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -22,8 +22,7 @@ class UhdmYosys(BaseRunner):
             {"preprocessing", "parsing", "elaboration"})
 
         self.submodule = "third_party/tools/yosys-uhdm-plugin-integration"
-        commit = self.get_commit()
-        self.url = "https://github.com/antmicro/yosys-uhdm-plugin-integration/tree/" + commit
+        self.url = f"https://github.com/antmicro/yosys-uhdm-plugin-integration/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         runner_scr = os.path.join(tmp_dir, "scr.sh")

--- a/tools/runners/UhdmYosys.py
+++ b/tools/runners/UhdmYosys.py
@@ -21,7 +21,9 @@ class UhdmYosys(BaseRunner):
             "yosys-uhdm", "yosys-uhdm",
             {"preprocessing", "parsing", "elaboration"})
 
-        self.url = "https://github.com/antmicro/yosys-uhdm-plugin-integration"
+        self.submodule = "third_party/tools/yosys-uhdm-plugin-integration"
+        commit = self.get_commit()
+        self.url = "https://github.com/antmicro/yosys-uhdm-plugin-integration/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         runner_scr = os.path.join(tmp_dir, "scr.sh")

--- a/tools/runners/Verible.py
+++ b/tools/runners/Verible.py
@@ -16,7 +16,9 @@ class Verible(BaseRunner):
     def __init__(self):
         super().__init__("verible", "verible-verilog-syntax", {"parsing"})
 
-        self.url = "https://github.com/chipsalliance/verible"
+        self.submodule = "third_party/tools/verible"
+        commit = self.get_commit()
+        self.url = "https://github.com/chipsalliance/verible/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/Verible.py
+++ b/tools/runners/Verible.py
@@ -17,8 +17,7 @@ class Verible(BaseRunner):
         super().__init__("verible", "verible-verilog-syntax", {"parsing"})
 
         self.submodule = "third_party/tools/verible"
-        commit = self.get_commit()
-        self.url = "https://github.com/chipsalliance/verible/tree/" + commit
+        self.url = f"https://github.com/chipsalliance/verible/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/VeribleExtractor.py
+++ b/tools/runners/VeribleExtractor.py
@@ -22,8 +22,7 @@ class VeribleExtractor(BaseRunner):
             {"parsing"})
 
         self.submodule = "third_party/tools/verible"
-        commit = self.get_commit()
-        self.url = "https://github.com/google/verible/tree/" + commit
+        self.url = f"https://github.com/google/verible/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         src_list_path = os.path.join(tmp_dir, "src_list")

--- a/tools/runners/VeribleExtractor.py
+++ b/tools/runners/VeribleExtractor.py
@@ -21,7 +21,9 @@ class VeribleExtractor(BaseRunner):
             "verible_extractor", "verible-verilog-kythe-extractor",
             {"parsing"})
 
-        self.url = "https://github.com/google/verible"
+        self.submodule = "third_party/tools/verible"
+        commit = self.get_commit()
+        self.url = "https://github.com/google/verible/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         src_list_path = os.path.join(tmp_dir, "src_list")

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -26,7 +26,8 @@ class Verilator(BaseRunner):
 
         self.c_extensions = ['.cc', '.c', '.cpp', '.h', '.hpp']
         self.allowed_extensions.extend(['.vlt'] + self.c_extensions)
-        self.url = "https://verilator.org"
+        self.submodule = "third_party/tools/verilator"
+        self.url = f"https://github.com/verilator/verilator/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         mode = params['mode']

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -20,8 +20,7 @@ class Yosys(BaseRunner):
             "yosys", "yosys", {"preprocessing", "parsing", "elaboration"})
 
         self.submodule = "third_party/tools/yosys"
-        commit = self.get_commit()
-        self.url = "https://github.com/YosysHQ/yosys/tree/" + commit
+        self.url = f"https://github.com/YosysHQ/yosys/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         run = os.path.join(tmp_dir, "run.sh")

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -19,7 +19,9 @@ class Yosys(BaseRunner):
         super().__init__(
             "yosys", "yosys", {"preprocessing", "parsing", "elaboration"})
 
-        self.url = "https://github.com/YosysHQ/yosys"
+        self.submodule = "third_party/tools/yosys"
+        commit = self.get_commit()
+        self.url = "https://github.com/YosysHQ/yosys/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         run = os.path.join(tmp_dir, "run.sh")

--- a/tools/runners/moore.py
+++ b/tools/runners/moore.py
@@ -21,7 +21,8 @@ class moore(BaseRunner):
         super().__init__(
             name, executable="moore", supported_features=supported_features)
 
-        self.url = "http://llhd.io/"
+        self.submodule = "third_party/tools/moore"
+        self.url = f"https://github.com/fabianschuiki/moore/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/sv_parser.py
+++ b/tools/runners/sv_parser.py
@@ -17,8 +17,7 @@ class sv_parser(BaseRunner):
         super().__init__("sv-parser", "parse_sv", {"preprocessing", "parsing"})
 
         self.submodule = "third_party/tools/sv-parser"
-        commit = self.get_commit()
-        self.url = "https://github.com/dalance/sv-parser/tree/" + commit
+        self.url = f"https://github.com/dalance/sv-parser/tree/{self.get_commit()}"
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/sv_parser.py
+++ b/tools/runners/sv_parser.py
@@ -16,7 +16,9 @@ class sv_parser(BaseRunner):
     def __init__(self):
         super().__init__("sv-parser", "parse_sv", {"preprocessing", "parsing"})
 
-        self.url = "https://github.com/dalance/sv-parser"
+        self.submodule = "third_party/tools/sv-parser"
+        commit = self.get_commit()
+        self.url = "https://github.com/dalance/sv-parser/tree/" + commit
 
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable]

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -25,7 +25,9 @@ class tree_sitter_verilog(BaseRunner):
     def __init__(self):
         super().__init__("tree-sitter-verilog", None, {"parsing"})
 
-        self.url = "https://github.com/tree-sitter/tree-sitter-verilog"
+        self.submodule = "third_party/tools/tree-sitter-verilog"
+        commit = self.get_commit()
+        self.url = "https://github.com/tree-sitter/tree-sitter-verilog/tree/" + commit
 
     def find_lib(self):
         local_lib = ''

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -26,8 +26,7 @@ class tree_sitter_verilog(BaseRunner):
         super().__init__("tree-sitter-verilog", None, {"parsing"})
 
         self.submodule = "third_party/tools/tree-sitter-verilog"
-        commit = self.get_commit()
-        self.url = "https://github.com/tree-sitter/tree-sitter-verilog/tree/" + commit
+        self.url = f"https://github.com/tree-sitter/tree-sitter-verilog/tree/{self.get_commit()}"
 
     def find_lib(self):
         local_lib = ''


### PR DESCRIPTION
This change adds commit hashes to project links that refer to GitHub repositories.

It should affect only the links used in the HTML reports of the results.
