### PR TITLE
Added `unsynthesizable` test parameter

### DIFF
--- a/conf/generators/templates/uvm-classes_0.sv
+++ b/conf/generators/templates/uvm-classes_0.sv
@@ -12,6 +12,7 @@
 :description: {0} class test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;
@@ -23,41 +24,41 @@ class C extends {0};
         super.new(name, parent);
         `uvm_info("RESULT", "new {0} created", UVM_LOW);
     endfunction
-    
+
     virtual function void build_phase(uvm_phase phase);
         super.build_phase(phase);
         `uvm_info("RESULT", "build phase completed", UVM_LOW);
     endfunction
-    
+
     virtual function void connect_phase(uvm_phase phase);
         super.connect_phase(phase);
         `uvm_info("RESULT", "connect phase completed", UVM_LOW);
     endfunction
-    
+
     virtual function void end_of_elaboration_phase(uvm_phase phase);
         super.end_of_elaboration_phase(phase);
         `uvm_info("RESULT", "end of elaboration phase completed", UVM_LOW);
     endfunction
-    
+
     virtual function void start_of_simulation_phase(uvm_phase phase);
         super.start_of_simulation_phase(phase);
         `uvm_info("RESULT", "start of simulation phase completed", UVM_LOW);
     endfunction
-    
+
     task run_phase(uvm_phase phase);
         `uvm_info("RESULT", "run phase phase completed", UVM_LOW);
     endtask
-    
+
     virtual function void extract_phase(uvm_phase phase);
         super.extract_phase(phase);
         `uvm_info("RESULT", "extract phase completed", UVM_LOW);
     endfunction
-    
+
     virtual function void check_phase(uvm_phase phase);
         super.check_phase(phase);
         `uvm_info("RESULT", "check phase completed", UVM_LOW);
     endfunction
-    
+
     virtual function void report_phase(uvm_phase phase);
         super.report_phase(phase);
         `uvm_info("RESULT", "report phase completed", UVM_LOW);

--- a/conf/generators/templates/uvm-classes_1.sv
+++ b/conf/generators/templates/uvm-classes_1.sv
@@ -12,6 +12,7 @@
 :description: {0} class test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;
@@ -37,13 +38,13 @@ endmodule
 class C extends {0};
     virtual output_if out_vif;
     virtual input_if in_vif;
-    
+
     `uvm_component_utils(C)
-    
+
     function new(string name, uvm_component parent = null);
         super.new(name, parent);
     endfunction
-    
+
     virtual function void connect_phase(uvm_phase phase);
         super.connect_phase(phase);
         assert(uvm_resource_db#(virtual input_if)::read_by_name(
@@ -51,11 +52,11 @@ class C extends {0};
         assert(uvm_resource_db#(virtual output_if)::read_by_name(
             "C", "output_if", out_vif));
     endfunction
-    
+
     virtual function void build_phase(uvm_phase phase);
         super.build_phase(phase);
     endfunction
-    
+
     task run_phase(uvm_phase phase);
         phase.raise_objection(this);
         `uvm_info("RESULT", $sformatf("Writing %0d to input interface", `PATTERN), UVM_LOW);
@@ -79,9 +80,9 @@ module top;
     input_if in(clk);
     output_if out(clk);
     dut d(in, out);
-    
+
     always #5 clk = !clk;
-    
+
     initial begin
         obj = new("C");
         uvm_resource_db#(virtual input_if)::set("C","input_if", in);

--- a/conf/generators/templates/uvm-classes_3.sv
+++ b/conf/generators/templates/uvm-classes_3.sv
@@ -12,6 +12,7 @@
 :description: {0} class test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;
@@ -28,7 +29,7 @@ endclass
 
 module top;
     C obj;
-    
+
     initial begin
         obj = new("C");
     end

--- a/generators/easyUVM
+++ b/generators/easyUVM
@@ -20,6 +20,7 @@ templ = """/*
 :incdirs: {1}
 :tags: uvm
 :timeout: 100
+:unsynthesizable: 1
 */
 """
 

--- a/tests/chapter-11/11.4.14.4--dynamic_array_stream-sim.sv
+++ b/tests/chapter-11/11.4.14.4--dynamic_array_stream-sim.sv
@@ -12,6 +12,7 @@
 :description: stream unpack simulation test with dynamic array
 :type: simulation elaboration parsing
 :tags: 11.4.14.4
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-11/11.4.14.4--dynamic_array_stream.sv
+++ b/tests/chapter-11/11.4.14.4--dynamic_array_stream.sv
@@ -11,6 +11,7 @@
 :name: dynamic_array_unpack_stream
 :description: stream unpack test with dynamic array
 :tags: 11.4.14.4
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-11/11.4.14.4--dynamic_array_stream_with.sv
+++ b/tests/chapter-11/11.4.14.4--dynamic_array_stream_with.sv
@@ -11,6 +11,7 @@
 :name: dynamic_array_unpack_stream_with
 :description: stream unpack test with dynamic array using with
 :tags: 11.4.14.4
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-12/12.7.3--foreach.sv
+++ b/tests/chapter-12/12.7.3--foreach.sv
@@ -11,6 +11,7 @@
 :name: foreach_loop
 :description: A module testing foreach loop
 :tags: 12.7.3
+:unsynthesizable: 1
 */
 module foreach_tb ();
 	string test [4] = '{"111", "222", "333", "444"};

--- a/tests/chapter-12/12.7.6--forever.sv
+++ b/tests/chapter-12/12.7.6--forever.sv
@@ -11,8 +11,9 @@
 :name: forever_loop
 :description: A module testing forever loop
 :tags: 12.7.6
+:unsynthesizable: 1
 */
-module foreach_tb ();
+module forever_tb ();
    initial begin
       forever begin : loop
 	 disable loop;

--- a/tests/chapter-13/13.3.1--task-static.sv
+++ b/tests/chapter-13/13.3.1--task-static.sv
@@ -12,6 +12,7 @@
 :description: static task test
 :tags: 13.3.1
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-13/13.4.2--function-static.sv
+++ b/tests/chapter-13/13.4.2--function-static.sv
@@ -11,6 +11,7 @@
 :name: function_static
 :description: static function test
 :tags: 13.4.2
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-13/13.4.4--fork-invalid.sv
+++ b/tests/chapter-13/13.4.4--fork-invalid.sv
@@ -13,6 +13,7 @@
 :should_fail_because: only fork-join_none is permitted inside a function
 :tags: 13.4.4
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-13/13.4.4--fork-valid.sv
+++ b/tests/chapter-13/13.4.4--fork-valid.sv
@@ -12,6 +12,7 @@
 :description: function valid fork test
 :tags: 13.4.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-14/14.3--clocking-block-signals-error.sv
+++ b/tests/chapter-14/14.3--clocking-block-signals-error.sv
@@ -13,6 +13,7 @@
 :should_fail_because: assigning to net from procedural context
 :type: simulation elaboration
 :tags: 14.3
+:unsynthesizable: 1
 */
 module top(input clk, input a, output b, output c);
 

--- a/tests/chapter-14/14.3--clocking-block-signals.sv
+++ b/tests/chapter-14/14.3--clocking-block-signals.sv
@@ -11,6 +11,7 @@
 :name: clocking_block_signals
 :description: clocking block with signals test
 :tags: 14.3
+:unsynthesizable: 1
 */
 module top(input clk, input a, output logic b, output logic c);
 

--- a/tests/chapter-14/14.3--clocking-block.sv
+++ b/tests/chapter-14/14.3--clocking-block.sv
@@ -11,6 +11,7 @@
 :name: clocking_block
 :description: clocking block test
 :tags: 14.3
+:unsynthesizable: 1
 */
 module top(input clk);
 

--- a/tests/chapter-14/14.3--default-clocking-block.sv
+++ b/tests/chapter-14/14.3--default-clocking-block.sv
@@ -11,6 +11,7 @@
 :name: default_clocking_block
 :description: default clocking block test
 :tags: 14.3
+:unsynthesizable: 1
 */
 module top(input clk);
 

--- a/tests/chapter-14/14.3--global-clocking-block.sv
+++ b/tests/chapter-14/14.3--global-clocking-block.sv
@@ -11,6 +11,7 @@
 :name: global_clocking_block
 :description: global clocking block test
 :tags: 14.3
+:unsynthesizable: 1
 */
 module top(input clk);
 

--- a/tests/chapter-15/15.5.1--named-event-trigger-blocking.sv
+++ b/tests/chapter-15/15.5.1--named-event-trigger-blocking.sv
@@ -12,6 +12,7 @@
 :description: Trigger named event, blocking
 :tags: 15.5
 :top_module: top
+:unsynthesizable: 1
 */
 
 

--- a/tests/chapter-15/15.5.1--named-event-trigger-non-blocking.sv
+++ b/tests/chapter-15/15.5.1--named-event-trigger-non-blocking.sv
@@ -12,6 +12,7 @@
 :description: Trigger named event, non-blocking
 :tags: 15.5
 :top_module: top
+:unsynthesizable: 1
 */
 
 

--- a/tests/chapter-15/15.5.2--named-event-wait.sv
+++ b/tests/chapter-15/15.5.2--named-event-wait.sv
@@ -12,6 +12,7 @@
 :description: Wait for a named event
 :tags: 15.5
 :top_module: top
+:unsynthesizable: 1
 */
 
 

--- a/tests/chapter-16/16.10--property-local-var-fail.sv
+++ b/tests/chapter-16/16.10--property-local-var-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: pipeline increments value by 4 but property expects incrementation by 3
 :type: simulation
 :tags: 16.10
+:unsynthesizable: 1
 */
 
 module clk_gen(

--- a/tests/chapter-16/16.10--property-local-var-uvm-fail.sv
+++ b/tests/chapter-16/16.10--property-local-var-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: pipeline increments value by 4 but property expects incrementation by 3
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.10--property-local-var-uvm.sv
+++ b/tests/chapter-16/16.10--property-local-var-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.10--property-local-var.sv
+++ b/tests/chapter-16/16.10--property-local-var.sv
@@ -12,6 +12,7 @@
 :description: property with local variables
 :type: simulation elaboration parsing
 :tags: 16.10
+:unsynthesizable: 1
 */
 
 module clk_gen(

--- a/tests/chapter-16/16.10--sequence-local-var-fail.sv
+++ b/tests/chapter-16/16.10--sequence-local-var-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: pipeline increments value by 4 but sequence expects incrementation by 3
 :type: simulation
 :tags: 16.10
+:unsynthesizable: 1
 */
 
 module clk_gen(

--- a/tests/chapter-16/16.10--sequence-local-var-uvm.sv
+++ b/tests/chapter-16/16.10--sequence-local-var-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.10--sequence-local-var.sv
+++ b/tests/chapter-16/16.10--sequence-local-var.sv
@@ -12,6 +12,7 @@
 :description: sequence with local variables
 :type: simulation elaboration parsing
 :tags: 16.10
+:unsynthesizable: 1
 */
 
 module clk_gen(

--- a/tests/chapter-16/16.11--sequence-subroutine-uvm.sv
+++ b/tests/chapter-16/16.11--sequence-subroutine-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-interface-prec-uvm.sv
+++ b/tests/chapter-16/16.12--property-interface-prec-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-interface-uvm-fail.sv
+++ b/tests/chapter-16/16.12--property-interface-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: mem_ctrl asserts read and write at the same time and property checks that one or the other is asserted
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-interface-uvm.sv
+++ b/tests/chapter-16/16.12--property-interface-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-prec-uvm-fail.sv
+++ b/tests/chapter-16/16.12--property-prec-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: mem_ctrl interleaves reads and writes and property requires to keep reading
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-prec-uvm.sv
+++ b/tests/chapter-16/16.12--property-prec-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-uvm-fail.sv
+++ b/tests/chapter-16/16.12--property-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: mem_ctrl asserts read and write at the same time and property checks that one or the other is asserted
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.12--property-uvm.sv
+++ b/tests/chapter-16/16.12--property-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.13--sequence-multiclock-uvm.sv
+++ b/tests/chapter-16/16.13--sequence-multiclock-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.14--assume-property-uvm-fail.sv
+++ b/tests/chapter-16/16.14--assume-property-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: dut asserts read and write at the same time
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.14--assume-property-uvm.sv
+++ b/tests/chapter-16/16.14--assume-property-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.15--property-disable-iff-fail.sv
+++ b/tests/chapter-16/16.15--property-disable-iff-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: disable iff uses wrong reset polarity
 :type: simulation
 :tags: 16.15
+:unsynthesizable: 1
 */
 
 module clk_gen(

--- a/tests/chapter-16/16.15--property-disable-iff.sv
+++ b/tests/chapter-16/16.15--property-disable-iff.sv
@@ -12,6 +12,7 @@
 :description: property with disable iff
 :type: simulation elaboration parsing
 :tags: 16.15
+:unsynthesizable: 1
 */
 
 module clk_gen(

--- a/tests/chapter-16/16.15--property-iff-uvm-fail.sv
+++ b/tests/chapter-16/16.15--property-iff-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: disable iff uses wrong reset polarity
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.15--property-iff-uvm.sv
+++ b/tests/chapter-16/16.15--property-iff-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.17--expect-uvm-fail.sv
+++ b/tests/chapter-16/16.17--expect-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: read is asserted every 2 cycles
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.17--expect-uvm.sv
+++ b/tests/chapter-16/16.17--expect-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.2--assert-final-uvm.sv
+++ b/tests/chapter-16/16.2--assert-final-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.2--assert-uvm.sv
+++ b/tests/chapter-16/16.2--assert-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.2--assert0-uvm.sv
+++ b/tests/chapter-16/16.2--assert0-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.2--assume-uvm-fail.sv
+++ b/tests/chapter-16/16.2--assume-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: adder returns wrong value and assume expects correct result (a+b)
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.2--assume-uvm.sv
+++ b/tests/chapter-16/16.2--assume-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-and-range-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-and-range-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-and-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-and-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-intersect-uvm-fail.sv
+++ b/tests/chapter-16/16.7--sequence-intersect-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: intersecting sequences must start and end at the same time but gnt1 is asserted later
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-intersect-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-intersect-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-or-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-or-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-throughout-uvm-fail.sv
+++ b/tests/chapter-16/16.7--sequence-throughout-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: gnt2 is not asserted
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-throughout-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-throughout-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-uvm-fail.sv
+++ b/tests/chapter-16/16.7--sequence-uvm-fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: mem_ctrl interleaves reads and writes and sequence requires to keep reading
 :type: simulation
 :tags: uvm uvm-assertions
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.7--sequence.sv
+++ b/tests/chapter-16/16.7--sequence.sv
@@ -11,6 +11,7 @@
 :name: sequence_test
 :description: sequence test
 :tags: 16.7
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-16/16.9--sequence-changed-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-changed-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.9--sequence-cons-repetition.sv
+++ b/tests/chapter-16/16.9--sequence-cons-repetition.sv
@@ -11,6 +11,7 @@
 :name: sequence_consecutive_repetition_test
 :description: sequence with consecutive repetition operator test
 :tags: 16.9
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-16/16.9--sequence-fell-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-fell-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.9--sequence-goto-repetition.sv
+++ b/tests/chapter-16/16.9--sequence-goto-repetition.sv
@@ -11,6 +11,7 @@
 :name: sequence_goto_repetition_test
 :description: sequence with goto repetition operator test
 :tags: 16.9
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-16/16.9--sequence-noncons-repetition.sv
+++ b/tests/chapter-16/16.9--sequence-noncons-repetition.sv
@@ -11,6 +11,7 @@
 :name: sequence_nonconsecutive_repetition_test
 :description: sequence with nonconsecutive repetition operator test
 :tags: 16.9
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-16/16.9--sequence-past-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-past-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.9--sequence-rose-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-rose-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-16/16.9--sequence-stable-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-stable-uvm.sv
@@ -13,6 +13,7 @@
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
 :timeout: 60
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.10--dynamic-constraint-modification_0.sv
+++ b/tests/chapter-18/18.10--dynamic-constraint-modification_0.sv
@@ -11,6 +11,7 @@
 :name: dynamic_constraint_modification_0
 :description: dynamic constraint modification test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11--in-line-random-variable-control_0.sv
+++ b/tests/chapter-18/18.11--in-line-random-variable-control_0.sv
@@ -11,6 +11,7 @@
 :name: in-line_random_variable-control_0
 :description: in-line random variable control test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11--in-line-random-variable-control_1.sv
+++ b/tests/chapter-18/18.11--in-line-random-variable-control_1.sv
@@ -11,6 +11,7 @@
 :name: in-line_random_variable-control_1
 :description: in-line random variable control test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11.1--in-line-constraint-checker_0.sv
+++ b/tests/chapter-18/18.11.1--in-line-constraint-checker_0.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraint_checker_0
 :description: in-line constraint checker test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.11.1--in-line-constraint-checker_1.sv
+++ b/tests/chapter-18/18.11.1--in-line-constraint-checker_1.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraint_checker_1
 :description: in-line constraint checker test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.12--randomization-of-scope-variables_1.sv
+++ b/tests/chapter-18/18.12--randomization-of-scope-variables_1.sv
@@ -11,6 +11,7 @@
 :name: randomization_of_scope_variables_1
 :description: Randomization of scope variables - std::randomize() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.12.1--adding-constraints-to-scope-variables_1.sv
+++ b/tests/chapter-18/18.12.1--adding-constraints-to-scope-variables_1.sv
@@ -11,6 +11,7 @@
 :name: adding_constraints_to_scope_variables_1
 :description: Adding constraints to scope variables—std::randomize() with - test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.1--urandom_1.sv
+++ b/tests/chapter-18/18.13.1--urandom_1.sv
@@ -11,6 +11,7 @@
 :name: urandom_1
 :description: urandom() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.1--urandom_3.sv
+++ b/tests/chapter-18/18.13.1--urandom_3.sv
@@ -11,6 +11,7 @@
 :name: urandom_3
 :description: urandom() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.2--urandom_range_1.sv
+++ b/tests/chapter-18/18.13.2--urandom_range_1.sv
@@ -11,6 +11,7 @@
 :name: urandom_range_1
 :description: urandom_range() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.2--urandom_range_2.sv
+++ b/tests/chapter-18/18.13.2--urandom_range_2.sv
@@ -11,6 +11,7 @@
 :name: urandom_range_2
 :description: urandom_range() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.2--urandom_range_3.sv
+++ b/tests/chapter-18/18.13.2--urandom_range_3.sv
@@ -11,6 +11,7 @@
 :name: urandom_range_3
 :description: urandom_range() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.3--srandom_0.sv
+++ b/tests/chapter-18/18.13.3--srandom_0.sv
@@ -11,6 +11,7 @@
 :name: srandom_0
 :description: srandom() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.4--get_randstate_0.sv
+++ b/tests/chapter-18/18.13.4--get_randstate_0.sv
@@ -11,6 +11,7 @@
 :name: get_randstate_0
 :description: get_randstate() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.13.5--set_randstate_0.sv
+++ b/tests/chapter-18/18.13.5--set_randstate_0.sv
@@ -11,6 +11,7 @@
 :name: set_randstate_0
 :description: set_randstate() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_0.sv
+++ b/tests/chapter-18/18.14--random-stability_0.sv
@@ -11,6 +11,7 @@
 :name: random_stability_0
 :description: random stability - urandom_range test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_1.sv
+++ b/tests/chapter-18/18.14--random-stability_1.sv
@@ -11,6 +11,7 @@
 :name: random_stability_1
 :description: random stability - shuffle test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_2.sv
+++ b/tests/chapter-18/18.14--random-stability_2.sv
@@ -11,6 +11,7 @@
 :name: random_stability_2
 :description: random stability - randcase test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14--random-stability_3.sv
+++ b/tests/chapter-18/18.14--random-stability_3.sv
@@ -11,6 +11,7 @@
 :name: random_stability_3
 :description: random stability - randcase test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.2--thread-stability_0.sv
+++ b/tests/chapter-18/18.14.2--thread-stability_0.sv
@@ -11,6 +11,7 @@
 :name: thread_stability_0
 :description: thread stability test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.2--thread-stability_1.sv
+++ b/tests/chapter-18/18.14.2--thread-stability_1.sv
@@ -11,6 +11,7 @@
 :name: thread_stability_1
 :description: thread stability test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.3--object-stability_0.sv
+++ b/tests/chapter-18/18.14.3--object-stability_0.sv
@@ -11,6 +11,7 @@
 :name: object_stability_0
 :description: object stability test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.14.3--object-stability_1.sv
+++ b/tests/chapter-18/18.14.3--object-stability_1.sv
@@ -11,6 +11,7 @@
 :name: object_stability_1
 :description: object stability test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.15--manually-seeding-randomize_0.sv
+++ b/tests/chapter-18/18.15--manually-seeding-randomize_0.sv
@@ -11,6 +11,7 @@
 :name: manually_seeding_randomize_0
 :description: manually seeding randomize test
 :tags: 18.15
+:unsynthesizable: 1
 */
 
 class a;

--- a/tests/chapter-18/18.15--manually-seeding-randomize_1.sv
+++ b/tests/chapter-18/18.15--manually-seeding-randomize_1.sv
@@ -11,6 +11,7 @@
 :name: manually_seeding_randomize_1
 :description: manually seeding randomize test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.17--random-sequence-generation-randsequence_0.sv
+++ b/tests/chapter-18/18.17--random-sequence-generation-randsequence_0.sv
@@ -12,6 +12,7 @@
 :description: randsequence test
 :type: simulation elaboration parsing
 :tags: 18.17
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17--random-sequence-generation-randsequence_2.sv
+++ b/tests/chapter-18/18.17--random-sequence-generation-randsequence_2.sv
@@ -12,6 +12,7 @@
 :description: randsequence test
 :type: simulation elaboration parsing
 :tags: 18.17
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.1--random-production-weights_0.sv
+++ b/tests/chapter-18/18.17.1--random-production-weights_0.sv
@@ -12,6 +12,7 @@
 :description: randsequence weights test
 :type: simulation elaboration parsing
 :tags: 18.17.1
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.2--if-else-production-statements_0.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_0.sv
@@ -12,6 +12,7 @@
 :description: randcase if-else test
 :type: simulation elaboration parsing
 :tags: 18.17.2
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.2--if-else-production-statements_0_fail.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_0_fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: switch variable not declared
 :type: elaboration
 :tags: 18.17.2
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.2--if-else-production-statements_2.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_2.sv
@@ -12,6 +12,7 @@
 :description: randcase if-else test
 :type: simulation elaboration parsing
 :tags: 18.17.2
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.2--if-else-production-statements_2_fail.sv
+++ b/tests/chapter-18/18.17.2--if-else-production-statements_2_fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: switch variable not declared
 :type: elaboration
 :tags: 18.17.2
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.3--case-production-statements_0.sv
+++ b/tests/chapter-18/18.17.3--case-production-statements_0.sv
@@ -12,6 +12,7 @@
 :description: randcase case statement test
 :type: simulation elaboration parsing
 :tags: 18.17.3
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.3--case-production-statements_0_fail.sv
+++ b/tests/chapter-18/18.17.3--case-production-statements_0_fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: switch variable not declared
 :type: elaboration
 :tags: 18.17.3
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.4--repeat-production-statements_0.sv
+++ b/tests/chapter-18/18.17.4--repeat-production-statements_0.sv
@@ -12,6 +12,7 @@
 :description: repeat statement test
 :type: simulation elaboration parsing
 :tags: 18.17.4
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.5--interleaving-productions-rand-join_0.sv
+++ b/tests/chapter-18/18.17.5--interleaving-productions-rand-join_0.sv
@@ -12,6 +12,7 @@
 :description: rand join statement test
 :type: simulation elaboration parsing
 :tags: 18.17.5
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.5--interleaving-productions-rand-join_2.sv
+++ b/tests/chapter-18/18.17.5--interleaving-productions-rand-join_2.sv
@@ -12,6 +12,7 @@
 :description: rand join statement test
 :type: simulation elaboration parsing
 :tags: 18.17.5
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.6--aborting-productions-break-and-return_0.sv
+++ b/tests/chapter-18/18.17.6--aborting-productions-break-and-return_0.sv
@@ -12,6 +12,7 @@
 :description: break statement test
 :type: simulation elaboration parsing
 :tags: 18.17.6
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.6--aborting-productions-break-and-return_2.sv
+++ b/tests/chapter-18/18.17.6--aborting-productions-break-and-return_2.sv
@@ -12,6 +12,7 @@
 :description: return statement test
 :type: simulation elaboration parsing
 :tags: 18.17.6
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.6--aborting-productions-break-and-return_2_fail.sv
+++ b/tests/chapter-18/18.17.6--aborting-productions-break-and-return_2_fail.sv
@@ -13,6 +13,7 @@
 :should_fail_because: typo in production name
 :type: elaboration
 :tags: 18.17.6
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.17.7--value-passing-between-productions_0.sv
+++ b/tests/chapter-18/18.17.7--value-passing-between-productions_0.sv
@@ -12,6 +12,7 @@
 :description: value passing in randsequence test
 :type: simulation elaboration parsing
 :tags: 18.17.7
+:unsynthesizable: 1
 */
 
 function int F();

--- a/tests/chapter-18/18.5--constraint-blocks_1.sv
+++ b/tests/chapter-18/18.5--constraint-blocks_1.sv
@@ -11,6 +11,7 @@
 :name: constraint_blocks_1
 :description: constraint blocks test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.1--explicit-external-constraint_2.sv
+++ b/tests/chapter-18/18.5.1--explicit-external-constraint_2.sv
@@ -11,6 +11,7 @@
 :name: explicit_external_constraint_2
 :description: explicit external constraint test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.1--implicit-external-constraint_2.sv
+++ b/tests/chapter-18/18.5.1--implicit-external-constraint_2.sv
@@ -11,6 +11,7 @@
 :name: implicit_external_constraint_2
 :description: implicit external constraint test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.11--static-constraint-blocks_0.sv
+++ b/tests/chapter-18/18.5.11--static-constraint-blocks_0.sv
@@ -11,6 +11,7 @@
 :name: static_constraint_blocks_0
 :description: static constraint blocks test
 :tags: 18.5.11
+:unsynthesizable: 1
 */
 
 class a;
@@ -18,5 +19,3 @@ class a;
 
     static constraint c1 { b == 5; }
 endclass
-
-

--- a/tests/chapter-18/18.5.11--static-constraint-blocks_1.sv
+++ b/tests/chapter-18/18.5.11--static-constraint-blocks_1.sv
@@ -11,6 +11,7 @@
 :name: static_constraint_blocks_1
 :description: static constraint blocks test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.12--functions-in-constraint_1.sv
+++ b/tests/chapter-18/18.5.12--functions-in-constraint_1.sv
@@ -11,6 +11,7 @@
 :name: functions_in_constraint_1
 :description: functions in constraint test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.13--constraint-guards_1.sv
+++ b/tests/chapter-18/18.5.13--constraint-guards_1.sv
@@ -11,6 +11,7 @@
 :name: constraint_guards_1
 :description: constraint guards test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14--soft-constraints_1.sv
+++ b/tests/chapter-18/18.5.14--soft-constraints_1.sv
@@ -11,6 +11,7 @@
 :name: soft_constraints_1
 :description: soft constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.1--soft-constraint-priorities_1.sv
+++ b/tests/chapter-18/18.5.14.1--soft-constraint-priorities_1.sv
@@ -11,6 +11,7 @@
 :name: soft_constraint_priorities_1
 :description: soft constraint priorities test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.1--soft-constraint-priorities_3.sv
+++ b/tests/chapter-18/18.5.14.1--soft-constraint-priorities_3.sv
@@ -11,6 +11,7 @@
 :name: soft_constraint_priorities_3
 :description: soft constraint priorities test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.1--soft-constraint-priorities_4.sv
+++ b/tests/chapter-18/18.5.14.1--soft-constraint-priorities_4.sv
@@ -11,6 +11,7 @@
 :name: soft_constraint_priorities_4
 :description: soft constraint priorities test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.2--discarding-soft-constraints_1.sv
+++ b/tests/chapter-18/18.5.14.2--discarding-soft-constraints_1.sv
@@ -11,6 +11,7 @@
 :name: discarding_soft_constraints_1
 :description: discarding soft constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.2--discarding-soft-constraints_3.sv
+++ b/tests/chapter-18/18.5.14.2--discarding-soft-constraints_3.sv
@@ -11,6 +11,7 @@
 :name: discarding_soft_constraints_3
 :description: discarding soft constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.14.2--discarding-soft-constraints_5.sv
+++ b/tests/chapter-18/18.5.14.2--discarding-soft-constraints_5.sv
@@ -11,6 +11,7 @@
 :name: discarding_soft_constraints_5
 :description: discarding soft constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.2--constraint-inheritance_1.sv
+++ b/tests/chapter-18/18.5.2--constraint-inheritance_1.sv
@@ -11,6 +11,7 @@
 :name: constraint_inheritance_1
 :description: contraint inheritance test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.2--pure-constraint_0.sv
+++ b/tests/chapter-18/18.5.2--pure-constraint_0.sv
@@ -11,6 +11,7 @@
 :name: pure_constraint_0
 :description: pure constraint test
 :tags: 18.5.2
+:unsynthesizable: 1
 */
 
 virtual class a;

--- a/tests/chapter-18/18.5.2--pure-constraint_1.sv
+++ b/tests/chapter-18/18.5.2--pure-constraint_1.sv
@@ -11,6 +11,7 @@
 :name: pure_constraint_1
 :description: pure constraint test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.3--set-membership_1.sv
+++ b/tests/chapter-18/18.5.3--set-membership_1.sv
@@ -11,6 +11,7 @@
 :name: set_membership_1
 :description: set membership test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.4--distribution_1.sv
+++ b/tests/chapter-18/18.5.4--distribution_1.sv
@@ -11,6 +11,7 @@
 :name: distribution_1
 :description: distribution test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.5--uniqueness-constraints_1.sv
+++ b/tests/chapter-18/18.5.5--uniqueness-constraints_1.sv
@@ -11,6 +11,7 @@
 :name: uniqueness_constraints_1
 :description: uniqueness constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.6--implication_1.sv
+++ b/tests/chapter-18/18.5.6--implication_1.sv
@@ -11,6 +11,7 @@
 :name: implication_1
 :description: implication test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.7--if-else-constraints_4.sv
+++ b/tests/chapter-18/18.5.7--if-else-constraints_4.sv
@@ -11,6 +11,7 @@
 :name: if_else_constraints_4
 :description: if-else constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.8.1--foreach-iterative-constraints_0.sv
+++ b/tests/chapter-18/18.5.8.1--foreach-iterative-constraints_0.sv
@@ -11,6 +11,7 @@
 :name: foreach_iterative_constraints_0
 :description: foreach iterative constraints test
 :tags: 18.5.8.1
+:unsynthesizable: 1
 */
 
 class a;

--- a/tests/chapter-18/18.5.8.1--foreach-iterative-constraints_1.sv
+++ b/tests/chapter-18/18.5.8.1--foreach-iterative-constraints_1.sv
@@ -11,6 +11,7 @@
 :name: foreach_iterative_constraints_1
 :description: foreach iterative constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.8.2--array-reduction-iterative-constraints_1.sv
+++ b/tests/chapter-18/18.5.8.2--array-reduction-iterative-constraints_1.sv
@@ -11,6 +11,7 @@
 :name: array_reduction_iterative_constraints_1
 :description: array reduction iterative constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.5.9--global-constraints_1.sv
+++ b/tests/chapter-18/18.5.9--global-constraints_1.sv
@@ -11,6 +11,7 @@
 :name: global_constraints_1
 :description: global constraints test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.1--randomize-method_0.sv
+++ b/tests/chapter-18/18.6.1--randomize-method_0.sv
@@ -11,6 +11,7 @@
 :name: randomize_method_0
 :description: randomize() method test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.2--post-randomize_method_1.sv
+++ b/tests/chapter-18/18.6.2--post-randomize_method_1.sv
@@ -11,6 +11,7 @@
 :name: post_randomize_method_1
 :description: post_randomize() method test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.2--pre-randomize-method_1.sv
+++ b/tests/chapter-18/18.6.2--pre-randomize-method_1.sv
@@ -11,6 +11,7 @@
 :name: pre_randomize_method_1
 :description: pre_randomize() method test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_0.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_0.sv
@@ -11,6 +11,7 @@
 :name: behavior_of_randomization_methods_0
 :description: static random variables test
 :tags: 18.6.3
+:unsynthesizable: 1
 */
 
 class a;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_1.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_1.sv
@@ -11,6 +11,7 @@
 :name: behavior_of_randomization_methods_1
 :description: static random variables test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_2.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_2.sv
@@ -11,6 +11,7 @@
 :name: behavior_of_randomization_methods_2
 :description: If randomize() fails, the constraints are infeasible, and the random variables retain their previous values.
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_3.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_3.sv
@@ -11,6 +11,7 @@
 :name: behavior_of_randomization_methods_3
 :description: If randomize() fails, post_randomize() is not called.
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.6.3--behavior-of-randomization-methods_5.sv
+++ b/tests/chapter-18/18.6.3--behavior-of-randomization-methods_5.sv
@@ -13,6 +13,7 @@
 :should_fail_because: The randomize() method is built-in and cannot be overridden.
 :tags: uvm-random uvm
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_0.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_0.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraints--randomize_0
 :description: in-line constraints test - randomize()
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_1.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_1.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraints--randomize_1
 :description: in-line constraints test - randomize()
 :tags: 18.7
+:unsynthesizable: 1
 */
 
 class a1;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_2.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_2.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraints--randomize_2
 :description: in-line constraints test - randomize()
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_4.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_4.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraints--randomize_4
 :description: in-line constraints test - randomize()
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7--in-line-constraints--randomize_6.sv
+++ b/tests/chapter-18/18.7--in-line-constraints--randomize_6.sv
@@ -11,6 +11,7 @@
 :name: in-line_constraints--randomize_6
 :description: in-line constraints test - randomize()
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.7.1--local-scope-resolution_1.sv
+++ b/tests/chapter-18/18.7.1--local-scope-resolution_1.sv
@@ -11,6 +11,7 @@
 :name: local_scope_resolution_1
 :description: local:: scope resolution test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_0.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_0.sv
@@ -11,6 +11,7 @@
 :name: disabling-random-variables-with-rand_mode_0
 :description: rand_mode() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_1.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_1.sv
@@ -11,6 +11,7 @@
 :name: disabling-random-variables-with-rand_mode_1
 :description: rand_mode() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_2.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_2.sv
@@ -11,6 +11,7 @@
 :name: disabling-random-variables-with-rand_mode_2
 :description: rand_mode() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_3.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_3.sv
@@ -11,6 +11,7 @@
 :name: disabling-random-variables-with-rand_mode_3
 :description: rand_mode() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_5.sv
+++ b/tests/chapter-18/18.8--disabling-random-variables-with-rand_mode_5.sv
@@ -13,6 +13,7 @@
 :should_fail_because: The rand_mode() method is built-in and cannot be overridden.
 :tags: uvm-random uvm
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_0.sv
+++ b/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_0.sv
@@ -11,6 +11,7 @@
 :name: controlling-constraints-with-constraint_mode_0
 :description: constraint_mode() test
 :tags: uvm-random uvm
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_2.sv
+++ b/tests/chapter-18/18.9--controlling-constraints-with-constraint_mode_2.sv
@@ -13,6 +13,7 @@
 :should_fail_because: The constraint_mode() method is built-in and cannot be overridden.
 :tags: uvm-random uvm
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/chapter-20/20.10--error.sv
+++ b/tests/chapter-20/20.10--error.sv
@@ -14,6 +14,7 @@
 :type: parsing
   Note this is not a simulation test, as the $warning may result in some
   simulators returning bad exit status.
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-20/20.10--fatal.sv
+++ b/tests/chapter-20/20.10--fatal.sv
@@ -14,6 +14,7 @@
 :type: parsing
   Note this is not a simulation test, as the $warning may result in some
   simulators returning bad exit status.
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-20/20.10--info.sv
+++ b/tests/chapter-20/20.10--info.sv
@@ -12,6 +12,7 @@
 :description: $info test
 :tags: 20.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-20/20.10--warning.sv
+++ b/tests/chapter-20/20.10--warning.sv
@@ -14,6 +14,7 @@
 :type: parsing
   Note this is not a simulation test, as the $warning may result in some
   simulators returning bad exit status.
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-20/20.14--coverage.sv
+++ b/tests/chapter-20/20.14--coverage.sv
@@ -12,6 +12,7 @@
 :description: coverage routine test
 :tags: 20.14
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 module DUT;

--- a/tests/chapter-20/20.2--exit.sv
+++ b/tests/chapter-20/20.2--exit.sv
@@ -11,6 +11,7 @@
 :name: exit_task
 :description: $exit test
 :tags: 20.2
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-20/20.2--finish.sv
+++ b/tests/chapter-20/20.2--finish.sv
@@ -11,6 +11,7 @@
 :name: finish_task
 :description: $finish test
 :tags: 20.2
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-20/20.2--stop.sv
+++ b/tests/chapter-20/20.2--stop.sv
@@ -11,6 +11,7 @@
 :name: stop_task
 :description: $stop test
 :tags: 20.2
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-20/20.3--realtime.sv
+++ b/tests/chapter-20/20.3--realtime.sv
@@ -11,6 +11,7 @@
 :name: realtime_task
 :description: $realtime test
 :tags: 20.3
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-20/20.3--stime.sv
+++ b/tests/chapter-20/20.3--stime.sv
@@ -11,6 +11,7 @@
 :name: stime_task
 :description: $stime test
 :tags: 20.3
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-20/20.3--time.sv
+++ b/tests/chapter-20/20.3--time.sv
@@ -11,6 +11,7 @@
 :name: time_task
 :description: $time test
 :tags: 20.3
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-20/20.4--printtimescale-hier.sv
+++ b/tests/chapter-20/20.4--printtimescale-hier.sv
@@ -12,6 +12,7 @@
 :description: $printtimescale hierarchy test
 :tags: 20.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 `timescale 1 ms / 1 us

--- a/tests/chapter-20/20.4--printtimescale.sv
+++ b/tests/chapter-20/20.4--printtimescale.sv
@@ -12,6 +12,7 @@
 :description: $printtimescale test
 :tags: 20.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 `timescale 1 ms / 1 us

--- a/tests/chapter-20/20.4--timeformat.sv
+++ b/tests/chapter-20/20.4--timeformat.sv
@@ -12,6 +12,7 @@
 :description: $timeformat test
 :tags: 20.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 `timescale 1 fs / 1 fs

--- a/tests/chapter-20/20.5--shortreal-bits-conv.sv
+++ b/tests/chapter-20/20.5--shortreal-bits-conv.sv
@@ -12,6 +12,7 @@
 :description: $shortrealtobits and $bitstoshortreal test
 :tags: 20.5
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 module top();

--- a/tests/chapter-21/21.2--display.sv
+++ b/tests/chapter-21/21.2--display.sv
@@ -12,6 +12,7 @@
 :description: $display test
 :tags: 21.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.2--monitor.sv
+++ b/tests/chapter-21/21.2--monitor.sv
@@ -12,6 +12,7 @@
 :description: $monitor test
 :tags: 21.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.2--strobe.sv
+++ b/tests/chapter-21/21.2--strobe.sv
@@ -12,6 +12,7 @@
 :description: $strobe test
 :tags: 21.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.2--write.sv
+++ b/tests/chapter-21/21.2--write.sv
@@ -12,6 +12,7 @@
 :description: $write test
 :tags: 21.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fdisplay.sv
+++ b/tests/chapter-21/21.3--fdisplay.sv
@@ -12,6 +12,7 @@
 :description: $fdisplay test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fflush.sv
+++ b/tests/chapter-21/21.3--fflush.sv
@@ -12,6 +12,7 @@
 :description: $fflush test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--file.sv
+++ b/tests/chapter-21/21.3--file.sv
@@ -12,6 +12,7 @@
 :description: $fopen and $fclose test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fmonitor.sv
+++ b/tests/chapter-21/21.3--fmonitor.sv
@@ -12,6 +12,7 @@
 :description: $fmonitor test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fpos.sv
+++ b/tests/chapter-21/21.3--fpos.sv
@@ -12,6 +12,7 @@
 :description: $fseek, $ftell and $rewind test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fread.sv
+++ b/tests/chapter-21/21.3--fread.sv
@@ -12,6 +12,7 @@
 :description: $fread test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fscanf.sv
+++ b/tests/chapter-21/21.3--fscanf.sv
@@ -12,6 +12,7 @@
 :description: $fscanf test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fstrobe.sv
+++ b/tests/chapter-21/21.3--fstrobe.sv
@@ -12,6 +12,7 @@
 :description: $fstrobe test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--fwrite.sv
+++ b/tests/chapter-21/21.3--fwrite.sv
@@ -12,6 +12,7 @@
 :description: $fwrite test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.3--sscanf.sv
+++ b/tests/chapter-21/21.3--sscanf.sv
@@ -12,6 +12,7 @@
 :description: $sscanf test
 :tags: 21.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.7--dumpfile.sv
+++ b/tests/chapter-21/21.7--dumpfile.sv
@@ -12,6 +12,7 @@
 :description: vcd dump tests
 :tags: 21.7
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-21/21.7--dumpports.sv
+++ b/tests/chapter-21/21.7--dumpports.sv
@@ -12,6 +12,7 @@
 :description: vcd dump ports tests
 :tags: 21.7
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-22/22.7--timescale-module.sv
+++ b/tests/chapter-22/22.7--timescale-module.sv
@@ -12,6 +12,7 @@
 :description: Test
 :tags: 22.7
 :type: preprocessing
+:unsynthesizable: 1
 */
 `timescale 10 ns / 1 ns
 module test;

--- a/tests/chapter-24/24.3--program.sv
+++ b/tests/chapter-24/24.3--program.sv
@@ -12,6 +12,7 @@
 :description: program construct test
 :tags: 24.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 program prog(input wire a, input wire b);
 	initial $display(":assert: (%d == %d)", a, b);

--- a/tests/chapter-5/5.7.2-real-token.sv
+++ b/tests/chapter-5/5.7.2-real-token.sv
@@ -11,6 +11,7 @@
 :name: real-token
 :description: Testing the real variable type
 :tags: 5.7.2
+:unsynthesizable: 1
 */
 module top();
   real a;

--- a/tests/chapter-5/5.8-time-literals.sv
+++ b/tests/chapter-5/5.8-time-literals.sv
@@ -11,6 +11,7 @@
 :name: time-literals
 :description: Examples of time literals
 :tags: 5.8
+:unsynthesizable: 1
 */
 
 `timescale 100ps/10ps

--- a/tests/chapter-6/6.12--real.sv
+++ b/tests/chapter-6/6.12--real.sv
@@ -11,6 +11,7 @@
 :name: real
 :description: real type tests
 :tags: 6.12
+:unsynthesizable: 1
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.12--real_bit_select.sv
+++ b/tests/chapter-6/6.12--real_bit_select.sv
@@ -13,6 +13,7 @@
 :should_fail_because: it is illegal to do bit select on real data type
 :tags: 6.12
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.12--real_bit_select_idx.sv
+++ b/tests/chapter-6/6.12--real_bit_select_idx.sv
@@ -13,6 +13,7 @@
 :should_fail_because: it is illegal to do bit select on real data type
 :tags: 6.12
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.12--real_edge.sv
+++ b/tests/chapter-6/6.12--real_edge.sv
@@ -13,6 +13,7 @@
 :should_fail_because: it is illegal to use edge event controls on real type
 :tags: 6.12
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
 	real a = 0.5;

--- a/tests/chapter-6/6.12--realtime.sv
+++ b/tests/chapter-6/6.12--realtime.sv
@@ -11,6 +11,7 @@
 :name: realtime
 :description: realtime type tests
 :tags: 6.12
+:unsynthesizable: 1
 */
 module top();
 	realtime a = 0.5;

--- a/tests/chapter-6/6.12--shortreal.sv
+++ b/tests/chapter-6/6.12--shortreal.sv
@@ -11,6 +11,7 @@
 :name: shortreal
 :description: shortreal type tests
 :tags: 6.12
+:unsynthesizable: 1
 */
 module top();
 	shortreal a = 0.5;

--- a/tests/chapter-6/6.14--chandle.sv
+++ b/tests/chapter-6/6.14--chandle.sv
@@ -11,6 +11,7 @@
 :name: chandle
 :description: chandle type tests
 :tags: 6.14
+:unsynthesizable: 1
 */
 module top();
 	chandle a;

--- a/tests/chapter-6/6.16.10--string_atoreal.sv
+++ b/tests/chapter-6/6.16.10--string_atoreal.sv
@@ -11,6 +11,7 @@
 :name: string_atoreal
 :description: string.atoreal()  tests
 :tags: 6.16.10
+:unsynthesizable: 1
 */
 module top();
 	string a = "4.76";

--- a/tests/chapter-6/6.17--event.sv
+++ b/tests/chapter-6/6.17--event.sv
@@ -11,6 +11,7 @@
 :name: event
 :description: event type tests
 :tags: 6.17
+:unsynthesizable: 1
 */
 module top();
 	event a;

--- a/tests/chapter-6/6.20.3--parameter_type.sv
+++ b/tests/chapter-6/6.20.3--parameter_type.sv
@@ -11,6 +11,7 @@
 :name: parameter_type
 :description: parameter type tests
 :tags: 6.20.3
+:unsynthesizable: 1
 */
 module top #(type T = real);
 endmodule

--- a/tests/chapter-6/6.20.6--const.sv
+++ b/tests/chapter-6/6.20.6--const.sv
@@ -11,6 +11,7 @@
 :name: const
 :description: const test
 :tags: 6.20.6
+:unsynthesizable: 1
 */
 module top();
 	class test_cls;

--- a/tests/chapter-6/6.23--type_op.sv
+++ b/tests/chapter-6/6.23--type_op.sv
@@ -11,6 +11,7 @@
 :name: type_op
 :description: type operator tests
 :tags: 6.23
+:unsynthesizable: 1
 */
 module top();
 	real a = 4.76;

--- a/tests/chapter-6/6.6.7--nettype_resolution_fn.sv
+++ b/tests/chapter-6/6.6.7--nettype_resolution_fn.sv
@@ -11,6 +11,7 @@
 :name: nettype_resolution_fn
 :description: user-defined nettype with resolution function tests
 :tags: 6.6.7
+:unsynthesizable: 1
 */
 module top();
 	function automatic real real_sum (input real driver[]);

--- a/tests/chapter-7/arrays/associative/arguments.sv
+++ b/tests/chapter-7/arrays/associative/arguments.sv
@@ -12,6 +12,7 @@
 :description: Test passing associative array as arugments support
 :tags: 7.9.10 7.8
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-first-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-first-index.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-first.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-first.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-index.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-last-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-last-index.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find-last.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find-last.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/find.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/find.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/max.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/max.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/min.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/min.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/unique-index.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/unique-index.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10 7.12.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/locator-methods/unique.sv
+++ b/tests/chapter-7/arrays/associative/locator-methods/unique.sv
@@ -12,6 +12,7 @@
 :description: Test support of array locator methods
 :tags: 7.12.1 7.12 7.10 7.12.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/other.sv
+++ b/tests/chapter-7/arrays/associative/other.sv
@@ -11,6 +11,7 @@
 :name: associative-arrays-other-types
 :description: Test associative arrays support
 :tags: 7.8.1
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/associative/wildcard.sv
+++ b/tests/chapter-7/arrays/associative/wildcard.sv
@@ -11,6 +11,7 @@
 :name: associative-arrays-wildcard
 :description: Test associative arrays support
 :tags: 7.8.1
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/index.sv
+++ b/tests/chapter-7/arrays/unpacked/index.sv
@@ -12,6 +12,7 @@
 :description: Test support of unpacked arrays index querying method
 :tags: 7.12.4 7.4.2 7.10 7.12.1
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/arrays/unpacked/subroutines.sv
+++ b/tests/chapter-7/arrays/unpacked/subroutines.sv
@@ -12,6 +12,7 @@
 :description: Test support of arrays as arugments to subroutines
 :tags: 7.7 7.4.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/basic.sv
+++ b/tests/chapter-7/queues/basic.sv
@@ -11,6 +11,7 @@
 :name: queues-basic
 :description: Test queues support
 :tags: 7.10
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/delete.sv
+++ b/tests/chapter-7/queues/delete.sv
@@ -12,6 +12,7 @@
 :description: Test queues delete function support
 :tags: 7.10.2.3 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/delete_assign.sv
+++ b/tests/chapter-7/queues/delete_assign.sv
@@ -12,6 +12,7 @@
 :description: Update queue by assignment (delete)
 :tags: 7.10.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/insert.sv
+++ b/tests/chapter-7/queues/insert.sv
@@ -12,6 +12,7 @@
 :description: Test queues insert function support
 :tags: 7.10.2.2 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/insert_assign.sv
+++ b/tests/chapter-7/queues/insert_assign.sv
@@ -12,6 +12,7 @@
 :description: Update queue by assignment (insert)
 :tags: 7.10.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/persistence.sv
+++ b/tests/chapter-7/queues/persistence.sv
@@ -12,6 +12,7 @@
 :description: Test status of persistence of references to elements of queue
 :tags: 7.10.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_back.sv
+++ b/tests/chapter-7/queues/pop_back.sv
@@ -12,6 +12,7 @@
 :description: Test queues pop_back function support
 :tags: 7.10.2.5 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_back_assing.sv
+++ b/tests/chapter-7/queues/pop_back_assing.sv
@@ -12,6 +12,7 @@
 :description: Update queue by assignment (pop_back)
 :tags: 7.10.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_front.sv
+++ b/tests/chapter-7/queues/pop_front.sv
@@ -12,6 +12,7 @@
 :description: Test queues pop_front function support
 :tags: 7.10.2.4 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/pop_front_assign.sv
+++ b/tests/chapter-7/queues/pop_front_assign.sv
@@ -12,6 +12,7 @@
 :description: Update queue by assignment (pop_front)
 :tags: 7.10.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_back.sv
+++ b/tests/chapter-7/queues/push_back.sv
@@ -12,6 +12,7 @@
 :description: Test queues push_back function support
 :tags: 7.10.2.7 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_back_assign.sv
+++ b/tests/chapter-7/queues/push_back_assign.sv
@@ -12,6 +12,7 @@
 :description: Update queue by assignment (push_back)
 :tags: 7.10.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_front.sv
+++ b/tests/chapter-7/queues/push_front.sv
@@ -12,6 +12,7 @@
 :description: Test queues push_front function support
 :tags: 7.10.2.6 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/push_front_assign.sv
+++ b/tests/chapter-7/queues/push_front_assign.sv
@@ -12,6 +12,7 @@
 :description: Update queue by assignment (push_front)
 :tags: 7.10.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/size.sv
+++ b/tests/chapter-7/queues/size.sv
@@ -12,6 +12,7 @@
 :description: Test queues size support
 :tags: 7.10.2.1 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-7/queues/slice.sv
+++ b/tests/chapter-7/queues/slice.sv
@@ -12,6 +12,7 @@
 :description: Test queues slice support
 :tags: 7.10.1 7.10.2
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module top ();
 

--- a/tests/chapter-8/8.10--static_methods.sv
+++ b/tests/chapter-8/8.10--static_methods.sv
@@ -11,6 +11,7 @@
 :name: static_methods
 :description: static class methods test
 :tags: 8.10
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.11--this.sv
+++ b/tests/chapter-8/8.11--this.sv
@@ -11,6 +11,7 @@
 :name: this
 :description: this keyword test
 :tags: 8.11
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.12--assignment.sv
+++ b/tests/chapter-8/8.12--assignment.sv
@@ -11,6 +11,7 @@
 :name: assignment
 :description: object assignment
 :tags: 8.12
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.12--shallow_copy.sv
+++ b/tests/chapter-8/8.12--shallow_copy.sv
@@ -11,6 +11,7 @@
 :name: shallow_copy
 :description: object shallow copy
 :tags: 8.12
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.13--inheritance.sv
+++ b/tests/chapter-8/8.13--inheritance.sv
@@ -11,6 +11,7 @@
 :name: inheritance
 :description: class inheritance test
 :tags: 8.13
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.14--override_member.sv
+++ b/tests/chapter-8/8.14--override_member.sv
@@ -11,6 +11,7 @@
 :name: override_member
 :description: class member override test
 :tags: 8.14
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.15--super-default-new.sv
+++ b/tests/chapter-8/8.15--super-default-new.sv
@@ -11,6 +11,7 @@
 :name: super-def-new
 :description: Base class has no user-defined constructor, derived class accesses superclass new()
 :tags: 8.15
+:unsynthesizable: 1
 */
 package test_pkg;
 

--- a/tests/chapter-8/8.15--super.sv
+++ b/tests/chapter-8/8.15--super.sv
@@ -11,6 +11,7 @@
 :name: super
 :description: accessing superclass methods via super
 :tags: 8.15
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.16--cast_func.sv
+++ b/tests/chapter-8/8.16--cast_func.sv
@@ -11,6 +11,7 @@
 :name: cast_func
 :description: $cast function test
 :tags: 8.16
+:unsynthesizable: 1
 */
 module class_tb ();
 	typedef enum { aaa, bbb, ccc, ddd, eee } values;

--- a/tests/chapter-8/8.17--constructor_const_arg.sv
+++ b/tests/chapter-8/8.17--constructor_const_arg.sv
@@ -11,6 +11,7 @@
 :name: constructor_const_arg
 :description: class inheritance with a constant constructor argument
 :tags: 8.17
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.19--instance_constant.sv
+++ b/tests/chapter-8/8.19--instance_constant.sv
@@ -11,6 +11,7 @@
 :name: instance_constant
 :description: class with instance constant variable
 :tags: 8.19
+:unsynthesizable: 1
 */
 module class_tb ();
 	class a_cls;

--- a/tests/chapter-8/8.20--virtual_method.sv
+++ b/tests/chapter-8/8.20--virtual_method.sv
@@ -11,6 +11,7 @@
 :name: virtual_method
 :description: class with virtual methods
 :tags: 8.20
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.21--abstract_class.sv
+++ b/tests/chapter-8/8.21--abstract_class.sv
@@ -11,6 +11,7 @@
 :name: abstract_class
 :description: class extending abstract class
 :tags: 8.21
+:unsynthesizable: 1
 */
 module class_tb ();
 	virtual class base_cls;

--- a/tests/chapter-8/8.21--abstract_class_inst.sv
+++ b/tests/chapter-8/8.21--abstract_class_inst.sv
@@ -13,6 +13,7 @@
 :should_fail_because: instantiating abstract class
 :tags: 8.21
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 	virtual class base_cls;

--- a/tests/chapter-8/8.22--dynamic_method_lookup.sv
+++ b/tests/chapter-8/8.22--dynamic_method_lookup.sv
@@ -11,6 +11,7 @@
 :name: dynamic_method_lookup
 :description: dynamic method selection with abstract base class
 :tags: 8.22
+:unsynthesizable: 1
 */
 module class_tb ();
 	virtual class base_cls;

--- a/tests/chapter-8/8.23--scope_resolution.sv
+++ b/tests/chapter-8/8.23--scope_resolution.sv
@@ -11,6 +11,7 @@
 :name: scope_resolution
 :description: access static method using scope resolution operator
 :tags: 8.23
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.24--out_of_block_methods.sv
+++ b/tests/chapter-8/8.24--out_of_block_methods.sv
@@ -11,6 +11,7 @@
 :name: out_of_block_methods
 :description: out-of-body method declaration
 :tags: 8.24
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.25--parametrized_class_extend.sv
+++ b/tests/chapter-8/8.25--parametrized_class_extend.sv
@@ -11,6 +11,7 @@
 :name: parametrized_class_extend
 :description: parametrized class extending another parametrized class
 :tags: 8.25
+:unsynthesizable: 1
 */
 module class_tb ();
 	class base_cls #(int b = 20);

--- a/tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
+++ b/tests/chapter-8/8.25.1--parametrized_class_invalid_scope_resolution.sv
@@ -13,6 +13,7 @@
 :should_fail_because: parametrized class invalid scope resolution
 :tags: 8.25.1
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 

--- a/tests/chapter-8/8.25.1--parametrized_class_scope_resolution.sv
+++ b/tests/chapter-8/8.25.1--parametrized_class_scope_resolution.sv
@@ -11,6 +11,7 @@
 :name: parametrized_class_scope_resolution
 :description: parametrized class scope resolution
 :tags: 8.25.1
+:unsynthesizable: 1
 */
 module class_tb ();
 

--- a/tests/chapter-8/8.26.2--implements.sv
+++ b/tests/chapter-8/8.26.2--implements.sv
@@ -11,6 +11,7 @@
 :name: implements
 :description: implements keyword test
 :tags: 8.26.2
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.2--implements_extends.sv
+++ b/tests/chapter-8/8.26.2--implements_extends.sv
@@ -11,6 +11,7 @@
 :name: implements_extends
 :description: class both implementing and extending
 :tags: 8.26.2
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.2--implements_multiple.sv
+++ b/tests/chapter-8/8.26.2--implements_multiple.sv
@@ -11,6 +11,7 @@
 :name: implements_multiple
 :description: class implementing multiple interfaces
 :tags: 8.26.2
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.3--type_access_implements.sv
+++ b/tests/chapter-8/8.26.3--type_access_implements.sv
@@ -12,6 +12,7 @@
 :description: access interface class type with scope resolution operator
 :tags: 8.26.3
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
+++ b/tests/chapter-8/8.26.3--type_access_implements_invalid.sv
@@ -13,6 +13,7 @@
 :should_fail_because: typedefs are not inherited by implements operator
 :tags: 8.26.3
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
+++ b/tests/chapter-8/8.26.4--illegal_forward_def_implements.sv
@@ -13,6 +13,7 @@
 :should_fail_because: implementing forward typedef for an interface class should fail
 :tags: 8.26.4
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 	typedef interface class ihello;

--- a/tests/chapter-8/8.26.4--illegal_implements_parameter.sv
+++ b/tests/chapter-8/8.26.4--illegal_implements_parameter.sv
@@ -13,6 +13,7 @@
 :should_fail_because: implementing parameter that resolves to an interface class is not allowed
 :tags: 8.26.4
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.5--cast_between_interface_classes.sv
+++ b/tests/chapter-8/8.26.5--cast_between_interface_classes.sv
@@ -11,6 +11,7 @@
 :name: cast_between_interface_classes
 :description: it should be possible to cast between implemented interface classes
 :tags: 8.26.2
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;
@@ -20,7 +21,7 @@ module class_tb ();
 	interface class itest;
 		pure virtual function void test();
 	endclass
-	
+
 	class Hello implements ihello, itest;
 		virtual function void hello();
 			$display("hello world");

--- a/tests/chapter-8/8.26.5--implemented_class_handle.sv
+++ b/tests/chapter-8/8.26.5--implemented_class_handle.sv
@@ -11,6 +11,7 @@
 :name: implemented_class_handle
 :description: it should be possible to assign object handle to a variable of an implemented class type
 :tags: 8.26.5
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
+++ b/tests/chapter-8/8.26.5--invalid_interface_instantiation.sv
@@ -13,6 +13,7 @@
 :should_fail_because: instantiating an interface class
 :tags: 8.26.5
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.6.1--name_conflict_resolved.sv
+++ b/tests/chapter-8/8.26.6.1--name_conflict_resolved.sv
@@ -12,6 +12,7 @@
 :description: resolved interface class method name conflict
 :tags: 8.26.6.1
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
+++ b/tests/chapter-8/8.26.6.1--name_conflict_unresolved.sv
@@ -13,6 +13,7 @@
 :should_fail_because: unresolved interface class method name conflict
 :tags: 8.26.6.1
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.26.7--partial_implementation.sv
+++ b/tests/chapter-8/8.26.7--partial_implementation.sv
@@ -11,6 +11,7 @@
 :name: partial_implementation
 :description: virtual classes can implement their interfaces partially
 :tags: 8.26.7
+:unsynthesizable: 1
 */
 module class_tb ();
 	interface class ihello;

--- a/tests/chapter-8/8.4--instantiation.sv
+++ b/tests/chapter-8/8.4--instantiation.sv
@@ -11,6 +11,7 @@
 :name: instantiation
 :description: simple class instantiation test
 :tags: 8.4
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.5--parameters.sv
+++ b/tests/chapter-8/8.5--parameters.sv
@@ -12,6 +12,7 @@
 :description: parametrized class test
 :tags: 8.5 8.25
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls #(parameter a = 12);

--- a/tests/chapter-8/8.5--properties.sv
+++ b/tests/chapter-8/8.5--properties.sv
@@ -12,6 +12,7 @@
 :description: class properties test
 :tags: 8.5
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.5--properties_enum.sv
+++ b/tests/chapter-8/8.5--properties_enum.sv
@@ -11,6 +11,7 @@
 :name: properties_enum
 :description: enum defined inside class
 :tags: 8.5
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.6--methods.sv
+++ b/tests/chapter-8/8.6--methods.sv
@@ -11,6 +11,7 @@
 :name: methods
 :description: class method test
 :tags: 8.6
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.7--constructor.sv
+++ b/tests/chapter-8/8.7--constructor.sv
@@ -12,6 +12,7 @@
 :description: class constructor test
 :tags: 8.7
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.7--constructor_param.sv
+++ b/tests/chapter-8/8.7--constructor_param.sv
@@ -12,6 +12,7 @@
 :description: class constructor with arguments test
 :tags: 8.7
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-8/8.7--constructor_super.sv
+++ b/tests/chapter-8/8.7--constructor_super.sv
@@ -11,6 +11,7 @@
 :name: constructor_super
 :description: class constructor super test
 :tags: 8.7 8.17
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.8--typed_constructor.sv
+++ b/tests/chapter-8/8.8--typed_constructor.sv
@@ -11,6 +11,7 @@
 :name: typed_constructor
 :description: class typed constructor test
 :tags: 8.8
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.8--typed_constructor_param.sv
+++ b/tests/chapter-8/8.8--typed_constructor_param.sv
@@ -11,6 +11,7 @@
 :name: typed_constructor_param
 :description: typed class constructor with parameters test
 :tags: 8.8
+:unsynthesizable: 1
 */
 module class_tb ();
 	class super_cls;

--- a/tests/chapter-8/8.9--static_properties.sv
+++ b/tests/chapter-8/8.9--static_properties.sv
@@ -11,6 +11,7 @@
 :name: static_properties
 :description: static class properties test
 :tags: 8.9
+:unsynthesizable: 1
 */
 module class_tb ();
 	class test_cls;

--- a/tests/chapter-9/9.3.2--parallel_block_join.sv
+++ b/tests/chapter-9/9.3.2--parallel_block_join.sv
@@ -11,6 +11,7 @@
 :name: parallel_block_join
 :description: parallel block check
 :tags: 9.3.2
+:unsynthesizable: 1
 */
 module parallel_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.3.2--parallel_block_join_any.sv
+++ b/tests/chapter-9/9.3.2--parallel_block_join_any.sv
@@ -11,6 +11,7 @@
 :name: parallel_block_join_any
 :description: parallel block check
 :tags: 9.3.2
+:unsynthesizable: 1
 */
 module parallel_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.3.2--parallel_block_join_none.sv
+++ b/tests/chapter-9/9.3.2--parallel_block_join_none.sv
@@ -11,6 +11,7 @@
 :name: parallel_block_join_none
 :description: parallel block check
 :tags: 9.3.2
+:unsynthesizable: 1
 */
 module parallel_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.3.3--block_start_finish.sv
+++ b/tests/chapter-9/9.3.3--block_start_finish.sv
@@ -11,6 +11,7 @@
 :name: block_start_finish
 :description: block start finish check
 :tags: 9.3.3
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg [3:0] a = 0;

--- a/tests/chapter-9/9.3.3--event.sv
+++ b/tests/chapter-9/9.3.3--event.sv
@@ -11,6 +11,7 @@
 :name: event_order
 :description: event order test
 :tags: 9.3.3
+:unsynthesizable: 1
 */
 module block_tb ();
 	event ev;

--- a/tests/chapter-9/9.3.3--fork_return.sv
+++ b/tests/chapter-9/9.3.3--fork_return.sv
@@ -13,6 +13,7 @@
 :should_fail_because: illegal return from fork
 :tags: 9.3.3
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module block_tb ();
 	task fork_test;

--- a/tests/chapter-9/9.3.4--block_names_par.sv
+++ b/tests/chapter-9/9.3.4--block_names_par.sv
@@ -11,6 +11,7 @@
 :name: block_names_par
 :description: parallel block names check
 :tags: 9.3.4
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.3.5--statement_labels_par.sv
+++ b/tests/chapter-9/9.3.5--statement_labels_par.sv
@@ -11,6 +11,7 @@
 :name: statement_labels_par
 :description: parallel block labels check
 :tags: 9.3.5
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.4.1--delay_control-sim.sv
+++ b/tests/chapter-9/9.4.1--delay_control-sim.sv
@@ -12,6 +12,7 @@
 :description: delay control simulation
 :tags: 9.4.1
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-9/9.4.1--delay_control-two-blocks-sim.sv
+++ b/tests/chapter-9/9.4.1--delay_control-two-blocks-sim.sv
@@ -12,6 +12,7 @@
 :description: delay control simulation with two blocks
 :tags: 9.4.1
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
 

--- a/tests/chapter-9/9.4.1--delay_control.sv
+++ b/tests/chapter-9/9.4.1--delay_control.sv
@@ -11,6 +11,7 @@
 :name: delay_control
 :description: delay control
 :tags: 9.4.1
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg [3:0] a = 0;

--- a/tests/chapter-9/9.4.2--event_control_sim.sv
+++ b/tests/chapter-9/9.4.2--event_control_sim.sv
@@ -12,6 +12,7 @@
 :description: Test event invocation
 :tags: 9.4.2
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
    event e;

--- a/tests/chapter-9/9.4.2--event_control_sim_minimal.sv
+++ b/tests/chapter-9/9.4.2--event_control_sim_minimal.sv
@@ -12,6 +12,7 @@
 :description: Test event invocation
 :tags: 9.4.2
 :type: simulation elaboration
+:unsynthesizable: 1
 */
 module top();
    event e;

--- a/tests/chapter-9/9.4.2.4--event_sequence.sv
+++ b/tests/chapter-9/9.4.2.4--event_sequence.sv
@@ -12,6 +12,7 @@
 :description: sequence event test
 :tags: 9.4.2.4
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 module seq_tb ();
 	logic a = 0;

--- a/tests/chapter-9/9.4.3--event_sequence_controls.sv
+++ b/tests/chapter-9/9.4.3--event_sequence_controls.sv
@@ -11,6 +11,7 @@
 :name: event_sequence_controls
 :description: event sequence
 :tags: 9.4.3
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.4.5--event_nonblocking_assignment_event.sv
+++ b/tests/chapter-9/9.4.5--event_nonblocking_assignment_event.sv
@@ -11,6 +11,7 @@
 :name: event_nonblocking_assignment_event
 :description: event non blk assignment event
 :tags: 9.4.5
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat.sv
+++ b/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat.sv
@@ -11,6 +11,7 @@
 :name: event_nonblocking_assignment_repeat
 :description: event non blk assignment repeat
 :tags: 9.4.5
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat_int.sv
+++ b/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat_int.sv
@@ -11,6 +11,7 @@
 :name: event_nonblocking_assignment_repeat_int
 :description: event non blk assignment repeat
 :tags: 9.4.5
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat_int_neg.sv
+++ b/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat_int_neg.sv
@@ -11,6 +11,7 @@
 :name: event_nonblocking_assignment_repeat_int_neg
 :description: event non blk assignment repeat
 :tags: 9.4.5
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat_neg.sv
+++ b/tests/chapter-9/9.4.5--event_nonblocking_assignment_repeat_neg.sv
@@ -11,6 +11,7 @@
 :name: event_nonblocking_assignment_repeat_neg
 :description: event non blk assignment repeat
 :tags: 9.4.5
+:unsynthesizable: 1
 */
 module block_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.6.1--wait_fork.sv
+++ b/tests/chapter-9/9.6.1--wait_fork.sv
@@ -11,6 +11,7 @@
 :name: wait_fork
 :description: wait fork test
 :tags: 9.6.1
+:unsynthesizable: 1
 */
 module fork_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.6.2--disable_other.sv
+++ b/tests/chapter-9/9.6.2--disable_other.sv
@@ -11,6 +11,7 @@
 :name: disable_other
 :description: disable other task
 :tags: 9.6.2
+:unsynthesizable: 1
 */
 module fork_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.6.3--disable_fork.sv
+++ b/tests/chapter-9/9.6.3--disable_fork.sv
@@ -11,6 +11,7 @@
 :name: disable_fork
 :description: disable fork
 :tags: 9.6.3
+:unsynthesizable: 1
 */
 module fork_tb ();
 	reg a = 0;

--- a/tests/chapter-9/9.7--process_cls_await.sv
+++ b/tests/chapter-9/9.7--process_cls_await.sv
@@ -11,6 +11,7 @@
 :name: process_cls_await
 :description: process class await method
 :tags: 9.7
+:unsynthesizable: 1
 */
 module process_tb ();
 	task automatic test (int N);

--- a/tests/chapter-9/9.7--process_cls_kill.sv
+++ b/tests/chapter-9/9.7--process_cls_kill.sv
@@ -11,6 +11,7 @@
 :name: process_cls_kill
 :description: process class kill method
 :tags: 9.7
+:unsynthesizable: 1
 */
 module process_tb ();
 	task automatic test (int N);

--- a/tests/chapter-9/9.7--process_cls_self.sv
+++ b/tests/chapter-9/9.7--process_cls_self.sv
@@ -11,6 +11,7 @@
 :name: process_cls_self
 :description: process class self method
 :tags: 9.7
+:unsynthesizable: 1
 */
 module process_tb ();
 	task automatic test (int N);

--- a/tests/chapter-9/9.7--process_cls_suspend_resume.sv
+++ b/tests/chapter-9/9.7--process_cls_suspend_resume.sv
@@ -11,6 +11,7 @@
 :name: process_control
 :description: process control
 :tags: 9.7
+:unsynthesizable: 1
 */
 module process_tb ();
 	task automatic test (int N);

--- a/tests/generic/class/class_test_30.sv
+++ b/tests/generic/class/class_test_30.sv
@@ -11,6 +11,7 @@
 :name: class_test_30
 :description: Test
 :tags: 6.15 8.3
+:unsynthesizable: 1
 */
 class Foo;
 integer size;

--- a/tests/generic/class/class_test_52.sv
+++ b/tests/generic/class/class_test_52.sv
@@ -11,6 +11,7 @@
 :name: class_test_52
 :description: Test
 :tags: 6.15 8.3
+:unsynthesizable: 1
 */
 class uvm_sequence_item;
 endclass

--- a/tests/generic/class/class_test_54.sv
+++ b/tests/generic/class/class_test_54.sv
@@ -11,6 +11,7 @@
 :name: class_test_54
 :description: Test
 :tags: 6.15 8.3
+:unsynthesizable: 1
 */
 class event_calendar;
   event birthday;

--- a/tests/generic/class/class_test_55.sv
+++ b/tests/generic/class/class_test_55.sv
@@ -11,6 +11,7 @@
 :name: class_test_55
 :description: Test
 :tags: 6.15 8.3
+:unsynthesizable: 1
 */
 class Packet;
 endclass

--- a/tests/generic/member/class_member_test_10.sv
+++ b/tests/generic/member/class_member_test_10.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_10
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class outerclass;
   class innerclass;

--- a/tests/generic/member/class_member_test_12.sv
+++ b/tests/generic/member/class_member_test_12.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_12
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class semaphore;
   local chandle p_handle;

--- a/tests/generic/member/class_member_test_27.sv
+++ b/tests/generic/member/class_member_test_27.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_27
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class report_server; endclass
 typedef int uvm_phase;

--- a/tests/generic/member/class_member_test_3.sv
+++ b/tests/generic/member/class_member_test_3.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_3
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class myclass;
 extern task subtask(int arg);

--- a/tests/generic/member/class_member_test_39.sv
+++ b/tests/generic/member/class_member_test_39.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_39
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class constructible;
 function new;

--- a/tests/generic/member/class_member_test_4.sv
+++ b/tests/generic/member/class_member_test_4.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_4
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class myclass;
 extern virtual task subtask(int arg);

--- a/tests/generic/member/class_member_test_40.sv
+++ b/tests/generic/member/class_member_test_40.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_40
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class constructible;
 function new ();

--- a/tests/generic/member/class_member_test_41.sv
+++ b/tests/generic/member/class_member_test_41.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_41
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class constructible;
 function new ();

--- a/tests/generic/member/class_member_test_5.sv
+++ b/tests/generic/member/class_member_test_5.sv
@@ -13,6 +13,7 @@
 :should_fail_because: pure virtual methods can only be declared in virtual classes
 :tags: 8.3
 :type: elaboration
+:unsynthesizable: 1
 */
 class myclass;
 pure virtual task pure_task1;

--- a/tests/generic/member/class_member_test_6.sv
+++ b/tests/generic/member/class_member_test_6.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_6
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class myclass;
 extern protected task subtask(int arg);

--- a/tests/generic/member/class_member_test_7.sv
+++ b/tests/generic/member/class_member_test_7.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_7
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class myclass;
 extern virtual protected task subtask(int arg);

--- a/tests/generic/member/class_member_test_8.sv
+++ b/tests/generic/member/class_member_test_8.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_8
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class myclass;
 extern protected virtual task subtask(int arg);

--- a/tests/generic/member/class_member_test_9.sv
+++ b/tests/generic/member/class_member_test_9.sv
@@ -11,6 +11,7 @@
 :name: class_member_test_9
 :description: Test
 :tags: 8.3
+:unsynthesizable: 1
 */
 class myclass;
 typedef int arg_type;

--- a/tests/testbenches/uvm_agent_active.sv
+++ b/tests/testbenches/uvm_agent_active.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-agents
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_agent_env.sv
+++ b/tests/testbenches/uvm_agent_env.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-agents
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_agent_passive.sv
+++ b/tests/testbenches/uvm_agent_passive.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-agents
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_driver_sequencer_env.sv
+++ b/tests/testbenches/uvm_driver_sequencer_env.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_monitor_env.sv
+++ b/tests/testbenches/uvm_monitor_env.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_resource_db_read_by_name.sv
+++ b/tests/testbenches/uvm_resource_db_read_by_name.sv
@@ -12,6 +12,7 @@
 :description: uvm resource_db::read_by_name test
 :tags: uvm
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_scoreboard_env.sv
+++ b/tests/testbenches/uvm_scoreboard_env.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-scoreboards
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_scoreboard_monitor_agent_env.sv
+++ b/tests/testbenches/uvm_scoreboard_monitor_agent_env.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-scoreboards
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_scoreboard_monitor_env.sv
+++ b/tests/testbenches/uvm_scoreboard_monitor_env.sv
@@ -13,6 +13,7 @@
 :tags: uvm uvm-scoreboards
 :type: simulation elaboration parsing
 :timeout: 30
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_sequence.sv
+++ b/tests/testbenches/uvm_sequence.sv
@@ -12,6 +12,7 @@
 :description: uvm_sequence test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/testbenches/uvm_test_run_test.sv
+++ b/tests/testbenches/uvm_test_run_test.sv
@@ -12,6 +12,7 @@
 :description: test if uvm_test instance can be called by name
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:unsynthesizable: 1
 */
 
 import uvm_pkg::*;

--- a/tests/uvm/uvm_files.sv
+++ b/tests/uvm/uvm_files.sv
@@ -12,5 +12,6 @@
 :description: basic UVM test
 :tags: uvm
 :timeout: 100
+:unsynthesizable: 1
 */
 

--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -59,9 +59,12 @@ class BaseRunner:
         self.url = "https://github.com/symbiflow/sv-tests"
         self.submodule = ""
 
-    def get_mode(self, test_features, compatible_runners):
+    def get_mode(self, params):
         """Determine correct run mode or return None when incompatible
         """
+        test_features = params['type'].split()
+        compatible_runners = params['compatible-runners'].split()
+
         if "all" not in compatible_runners:
             if self.name not in compatible_runners:
                 return None

--- a/tools/runner
+++ b/tools/runner
@@ -113,7 +113,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners", "results_group"
+    "compatible-runners", "unsynthesizable", "results_group"
 ]
 
 test_params = {}
@@ -158,6 +158,7 @@ try:
             test_params.setdefault('should_fail_because', "")
             test_params.setdefault('defines', "")
             test_params.setdefault('compatible-runners', "all")
+            test_params.setdefault('unsynthesizable', '0')
             test_params.setdefault('results_group', "")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
@@ -188,8 +189,7 @@ test_params['incdirs'] = list(
         lambda x: os.path.abspath(os.path.join(dirs['tests'], x)),
         test_params['incdirs'].split()))
 
-test_params['mode'] = runner_obj.get_mode(
-    test_params['type'].split(), test_params['compatible-runners'].split())
+test_params['mode'] = runner_obj.get_mode(test_params)
 if test_params['mode'] is None:
     logger.info("Skipping {}/{}".format(args.runner, args.test))
     with open(out, "w") as f:

--- a/tools/runners/SynligYosys.py
+++ b/tools/runners/SynligYosys.py
@@ -24,6 +24,12 @@ class SynligYosys(BaseRunner):
         self.submodule = "third_party/tools/synlig"
         self.url = f"https://github.com/chipsalliance/synlig/tree/{self.get_commit()}"
 
+    def get_mode(self, params):
+        unsynthesizable = int(params['unsynthesizable'])
+        if unsynthesizable:
+            return None
+        return super().get_mode(params)
+
     def prepare_run_cb(self, tmp_dir, params):
         runner_scr = os.path.join(tmp_dir, "scr.sh")
         yosys_scr = os.path.join(tmp_dir, "yosys-script")

--- a/tools/runners/Yosys.py
+++ b/tools/runners/Yosys.py
@@ -22,6 +22,12 @@ class Yosys(BaseRunner):
         self.submodule = "third_party/tools/yosys"
         self.url = f"https://github.com/YosysHQ/yosys/tree/{self.get_commit()}"
 
+    def get_mode(self, params):
+        unsynthesizable = int(params['unsynthesizable'])
+        if unsynthesizable:
+            return None
+        return super().get_mode(params)
+
     def prepare_run_cb(self, tmp_dir, params):
         run = os.path.join(tmp_dir, "run.sh")
         scr = os.path.join(tmp_dir, 'scr.ys')

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -284,6 +284,7 @@ class TestResult:
     tags: Set[str] = dataclasses.field(default_factory=set)
     types: Set[str] = dataclasses.field(default_factory=set)
     results_group: str = ""
+    unsynthesizable: str = ""
     input_files: List[str] = dataclasses.field(default_factory=list)
     # Unit: bytes
     total_input_files_size: int = 0
@@ -549,7 +550,7 @@ def collect_logs(runner_name: str):
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
             "should_fail_because", "defines", "compatible-runners",
-            "results_group"
+            "unsynthesizable", "results_group"
         }
         test_log_data: Dict[str, Any] = {}
         log_content = ""
@@ -596,6 +597,7 @@ def collect_logs(runner_name: str):
         # Test Result
 
         test_result.name = test_log_data["name"]
+        test_result.unsynthesizable = test_log_data["unsynthesizable"]
         test_result.results_group = test_log_data["results_group"]
 
         # Convert splitted "tags" to set() and append all meta-tags


### PR DESCRIPTION
## Summary

I added functionality to disable certain tests if they are unsynthesizable. I added the `unsynthesizable` parameter, and applied it to over 300 tests. If **Yosys** or **Synlig** encounters an unsynthesizable test, it will not run.

This PR is meant as a stepstone to #5082

Happy to make edits as requested!

## Tests Changed

I primarily based my decision of whether to mark a test as unsynthesizable by recommendation of this book:

* *RTL Modeling with SystemVerilog For Simulation and Synthesis: Using SystemVerilog for ASIC and FPGA Design* by Stuart Sutherland (ISBN: 978-1-5467-7634-5)

I marked the following tests as unsynthesizable:

* Anything using UVM
* Anything with delay
* Anything with non-const static functions
* Anything with loops of ambiguous length
* Anything with non-parameter variables with the following types:
  * `chandle`
  * `event`
  * `time`
  * `string`
  * `real`
* Anything with the following keywords:
  * `$cast`
  * `[*]`
  * `[$]`
  * `class` and `new`
  * `program`
  * `clocking`
  * `wait`
  * `fork`
  * `sequence`