### PR TITLE
Skip the `uvm` directory in VeeR-EL2

### DIFF
--- a/generators/veer-config
+++ b/generators/veer-config
@@ -110,6 +110,10 @@ for v in variants:
         for (dirpath, dirnames,
              filenames) in os.walk(os.path.join(third_party_dir, "cores", name,
                                                 "testbench")):
+            if 'uvm' in dirnames:
+                # Skip uvm dir as it uses a custom Makefile
+                dirnames.remove('uvm')
+
             for f in filenames:
                 if f.endswith(("sv", "v")):
                     sources += os.path.abspath(os.path.join(dirpath, f)) + " "


### PR DESCRIPTION
UVM tests in VeeR use a different structure that is incompatible with the VeeR generator.