### PR TITLE
Freeze tree_sitter version

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
-tree_sitter
+tree_sitter==0.20.4
 pygments
 yapf==0.30.0
 psutil


### PR DESCRIPTION
The ``build_library`` call that tree-sitter-verilog uses has been deprecated in 0.22, we need to stick to an older version.