### PR TITLE
Fix ariane generator

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -70,6 +70,9 @@ def process_filelist(filelist):
                 continue
 
             l = l.replace("${CVA6_REPO_DIR}", ariane_path)
+            l = l.replace(
+                "${HPDCACHE_DIR}",
+                f"{ariane_path}/core/cache_subsystem/hpdcache")
             l = l.replace("${TARGET_CFG}", "cv64a6_imafdc_sv39")
             if l.startswith("+incdir+"):
                 incdirs += l.partition("+incdir+")[2] + ' '


### PR DESCRIPTION
A new envirnment variable `HPDCACHE_DIR` is used to replace some paths in the upstream repository. Replace it with the correct path.

I did not test this, but the generated list of files seems correct. Let's see if the CI agrees.

Fixes #5799