### PR TITLE
Fix ariane generator (again)

### DIFF
--- a/generators/ariane
+++ b/generators/ariane
@@ -78,6 +78,9 @@ def process_filelist(filelist):
                 incdirs += l.partition("+incdir+")[2] + ' '
             elif l.startswith("+define+"):
                 defines += l.partition("+define+")[2] + ' '
+            elif l.startswith("-F"):
+                # recursively parse filelists
+                process_filelist(l.partition(' ')[2])
             elif l.endswith(".sv"):
                 sources.append(l)
 


### PR DESCRIPTION
Ariane seems to require recursive filelists. This commit adds recursive filelist parsing to the Ariane generator.

I am trying to set up a local instance of sv-tests, but compiling all the runners takes a while. In the meantime, we can also check what the CI says.

This commit (hopefully) fixes #5807