### PR TITLE
Add PR write permissions to the comment bot

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -75,6 +75,8 @@ jobs:
 
       - name: Post comment
         uses: KeisukeYamashita/create-comment@v1
+        permissions:
+          pull-requests: write
         with:
           number: ${{ steps.get-pr-number.outputs.num }}
           check-only-first-line: "true"


### PR DESCRIPTION
This is required to post a comment after the latest changes in GH api.