### PR TITLE
Add CI job for tree-sitter-systemverilog

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -30,6 +30,8 @@ jobs:
           - name: sv-parser
             deps: cargo
             rust_ver: "1.74"
+          - name: tree-sitter-systemverilog
+            deps: gcc
           - name: tree-sitter-verilog
             deps: npm
           - name: verible

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Finally the file containing the test case and metadata should be placed in `test
 * [Icarus](http://iverilog.icarus.com)
 * [slang](https://github.com/MikePopoloski/slang)
 * [sv2v(zachjs)](https://github.com/zachjs/sv2v)
+* [tree-sitter-systemverilog](https://github.com/gmlarumbe/tree-sitter-systemverilog)
 * [tree-sitter-verilog](https://github.com/tree-sitter/tree-sitter-verilog)
 * [sv-parser](https://github.com/dalance/sv-parser)
 * [moore](http://llhd.io)

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -182,6 +182,6 @@ $(INSTALL_DIR)/bin/circt-verilog:
 	ninja && ninja install
 
 # setup the dependencies
-RUNNERS_TARGETS := odin yosys icarus verilator slang zachjs-sv2v tree-sitter-verilog sv-parser moore verible surelog yosys-synlig verilator-uhdm circt-verilog
+RUNNERS_TARGETS := odin yosys icarus verilator slang zachjs-sv2v tree-sitter-systemverilog tree-sitter-verilog sv-parser moore verible surelog yosys-synlig verilator-uhdm circt-verilog
 .PHONY: $(RUNNERS_TARGETS)
 runners: $(RUNNERS_TARGETS)


### PR DESCRIPTION
The parser is missing in the public report since I forgot to add a CI job for it. 

I simply added an entry in the RUNNERS_TARGETS var of the runners.mk file. Not sure if something else is needed. I also added it to the list of supported tools in the README.md

Let me know if something else is needed.

Thanks!