### PR TITLE
Bump tree-sitter version to 0.23.0

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -1,6 +1,6 @@
 pyyaml
 jinja2
-tree_sitter==0.20.4
+tree_sitter==0.23.0
 pygments
 yapf==0.30.0
 psutil


### PR DESCRIPTION
Separate PR from #6076 to update tree-sitter to a newer version after adding tree-sitter-systemverilog CI jobs.