### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -214,6 +214,7 @@ jobs:
           apt install -y python3 python3-pip wget git curl jq
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+          pip install --upgrade setuptools
           pip install -r conf/requirements.txt
       - name: Prepare output directories
         run: |

--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -97,6 +97,7 @@ jobs:
           apt install -y python3 python3-pip git wget
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
+          pip install --upgrade setuptools
           pip install -r conf/requirements.txt
       - name: Install VeeR dependencies
         run: |

--- a/.github/workflows/sv-tests-code-quality.yml
+++ b/.github/workflows/sv-tests-code-quality.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: true
       - uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Script
         run:
           pip install -r conf/requirements.txt


### PR DESCRIPTION
One of the pip packages requires newer `setuptools` version, which causes the CI to fail. Updating `setuptools` before installing packages should solve the issue. 

Also Ubuntu24 does not support python 3.7 so I updated it to 3.8 (newer versions do not have `lib2to3`)