### PR TITLE
Bump `cache` action

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -150,7 +150,7 @@ jobs:
         with:
           format: 'YYYY-MM-DD-HH-mm-ss'
       - name: Setup cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         timeout-minutes: 3
         continue-on-error: true
         with:


### PR DESCRIPTION
`cache@v2` is deprecated. This bumps it to `v4`.