### PR TITLE
Bump rustc version for sv-parser

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -29,7 +29,7 @@ jobs:
             deps: cmake default-jre pkg-config tclsh uuid-dev
           - name: sv-parser
             deps: cargo
-            rust_ver: "1.74"
+            rust_ver: "1.81"
           - name: tree-sitter-systemverilog
             deps: gcc
           - name: tree-sitter-verilog


### PR DESCRIPTION
CI fails because one of the `sv-parser` dependencies expects newer `rustc` version (`1.81` according to the error message).