### PR TITLE
Fix `/bin/sh: 1: file: not found` errors

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -94,7 +94,7 @@ jobs:
           apt-get update -qq
       - name: Install common dependencies
         run: |
-          apt install -y python3 python3-pip git wget
+          apt install -y python3 python3-pip git wget file
           update-alternatives --install /usr/bin/python python /usr/bin/python3 1
           update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
           pip install --upgrade setuptools


### PR DESCRIPTION
Many jobs in `sv-tests-ci` emit `/bin/sh: 1: file: not found` error messages. Installing `file` solves the issue. 