### PR TITLE
Exclude a broken test from ivtests

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -283,6 +283,8 @@ ivtest_file_exclude = [
     'pr2800985a',
     # primitive table rows are invalid, fails on multiple commercial tools
     "pr3587570",
+    # Compilation errors with other simulators
+    "pr1520314",
 ]
 
 ivtest_long = ['comp1000', 'comp1001']


### PR DESCRIPTION
Excluding `pr1520314` test from ivtests, since it doesn't compile with other simulators. The test is trying to assign signals that were previously associated with other signals, resulting in compilation errors.