### PR TITLE
Add test for named function/task/module end- block

### DIFF
--- a/tests/chapter-13/13.3--task-label.sv
+++ b/tests/chapter-13/13.3--task-label.sv
@@ -1,0 +1,25 @@
+// Copyright (C) 2019-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+
+/*
+ :name: task-label
+ :description: test w/ named end test
+ :tags: 13.3
+ :type: simulation elaboration parsing
+ */
+module top();
+
+  task mytask;
+	$display(":assert: True");
+  endtask : mytask
+
+  initial
+	mytask;
+
+endmodule

--- a/tests/chapter-13/13.3--task-label.sv
+++ b/tests/chapter-13/13.3--task-label.sv
@@ -16,10 +16,10 @@
 module top();
 
   task mytask;
-	$display(":assert: True");
+    $display(":assert: True");
   endtask : mytask
 
   initial
-	mytask;
+    mytask;
 
 endmodule

--- a/tests/chapter-13/13.3--task-label.sv
+++ b/tests/chapter-13/13.3--task-label.sv
@@ -8,11 +8,11 @@
 
 
 /*
- :name: task-label
- :description: test w/ named end test
- :tags: 13.3
- :type: simulation elaboration parsing
- */
+:name: task-label
+:description: test w/ named end test
+:tags: 13.3
+:type: simulation elaboration parsing
+*/
 module top();
 
   task mytask;

--- a/tests/chapter-13/13.4--function-label.sv
+++ b/tests/chapter-13/13.4--function-label.sv
@@ -8,11 +8,11 @@
 
 
 /*
- :name: function
- :description: function w/ named end test
- :tags: 13.4
- :type: simulation elaboration parsing
- */
+:name: function
+:description: function w/ named end test
+:tags: 13.4
+:type: simulation elaboration parsing
+*/
 module top();
 
   function int test(int val);

--- a/tests/chapter-13/13.4--function-label.sv
+++ b/tests/chapter-13/13.4--function-label.sv
@@ -1,0 +1,25 @@
+// Copyright (C) 2019-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+
+/*
+ :name: function
+ :description: function w/ named end test
+ :tags: 13.4
+ :type: simulation elaboration parsing
+ */
+module top();
+
+  function int test(int val);
+	return val + 1;
+  endfunction : test
+
+  initial
+	$display(":assert: (%d == 2)", test(1));
+
+endmodule

--- a/tests/chapter-13/13.4--function-label.sv
+++ b/tests/chapter-13/13.4--function-label.sv
@@ -16,10 +16,10 @@
 module top();
 
   function int test(int val);
-	return val + 1;
+    return val + 1;
   endfunction : test
 
   initial
-	$display(":assert: (%d == 2)", test(1));
+    $display(":assert: (%d == 2)", test(1));
 
 endmodule

--- a/tests/chapter-23/23.2--module-label.sv
+++ b/tests/chapter-23/23.2--module-label.sv
@@ -11,6 +11,7 @@
 :name: module_definition
 :description: module w/ named end test
 :tags: 23.2
+:type: simulation elaboration parsing
 */
 module top();
 

--- a/tests/chapter-23/23.2--module-label.sv
+++ b/tests/chapter-23/23.2--module-label.sv
@@ -8,10 +8,10 @@
 
 
 /*
- :name: module_definition
- :description: module w/ named end test
- :tags: 23.2
- */
+:name: module_definition
+:description: module w/ named end test
+:tags: 23.2
+*/
 module top();
 
 endmodule : top

--- a/tests/chapter-23/23.2--module-label.sv
+++ b/tests/chapter-23/23.2--module-label.sv
@@ -1,0 +1,17 @@
+// Copyright (C) 2019-2021  The SymbiFlow Authors.
+//
+// Use of this source code is governed by a ISC-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/ISC
+//
+// SPDX-License-Identifier: ISC
+
+
+/*
+ :name: module_definition
+ :description: module w/ named end test
+ :tags: 23.2
+ */
+module top();
+
+endmodule : top


### PR DESCRIPTION
As per LRM 1800-2017, section 9.3.4, added task/function/module with named labels.