### PR TITLE
Bump Verible to `7aae5c08`

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -35,7 +35,7 @@ jobs:
           - name: tree-sitter-verilog
             deps: npm
           - name: verible
-            deps: bazel=5.4.0 bison flex libfl-dev
+            deps: bazel=7.6.1 bison flex libfl-dev
             skip-ccache: 1
           - name: verilator
             deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev

--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -128,7 +128,9 @@ $(RDIR)/moore/Cargo.lock: $(CDIR)/runners/Cargo.lock
 
 # verible
 verible:
-	cd $(RDIR)/verible/ && bazel run :install --noshow_progress --//bazel:use_local_flex_bison -c opt -- $(INSTALL_DIR)/bin && bazel shutdown
+	cd $(RDIR)/verible/ && bazel build :install-binaries --noshow_progress --//bazel:use_local_flex_bison -c opt
+	cd $(RDIR)/verible/ && .github/bin/simple-install.sh $(INSTALL_DIR)/bin
+	cd $(RDIR)/verible/ && bazel shutdown
 
 $(INSTALL_DIR)/bin/verible-verilog-kythe-extractor: verible
 


### PR DESCRIPTION
Verible installation is [done differently](https://github.com/chipsalliance/verible/pull/2298) now, reflected by this change.