### PR TITLE
Remove dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gitsubmodule
-  directory: "/"
-  schedule:
-    interval: daily
-    # UTC
-    time: "22:00"
-  open-pull-requests-limit: 30


### PR DESCRIPTION
Remove dependabot config in the hope that restoring it later will fix it not opening new PRs.