### PR TITLE
Fix parse-only mode for circt-verilog

### DIFF
--- a/tools/runners/circt_verilog.py
+++ b/tools/runners/circt_verilog.py
@@ -35,7 +35,7 @@ class circt_verilog(BaseRunner):
         if mode == "preprocessing":
             self.cmd += ["-E"]
         elif mode == "parsing":
-            self.cmd += "--parse-only"
+            self.cmd += ["--parse-only"]
 
         # Setting for additional include search paths.
         for incdir in params["incdirs"]:


### PR DESCRIPTION
Fix a typo in the circt-verilog Python runner script.