### PR TITLE
Fix sequence-throughout test

### DIFF
--- a/tests/chapter-16/16.7--sequence-throughout-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-throughout-uvm.sv
@@ -117,7 +117,7 @@ module top();
         @(posedge dif.clk) (dif.req ##5 dif.gnt0) intersect (dif.req ##[1:9] dif.gnt1);
     endsequence
 
-    assert property (dif.gnt2 throughout seq) else `uvm_error(label, $sformatf("seq failed :assert: (False)"));
+    assert property (@(posedge dif.clk) dif.gnt2 throughout seq) else `uvm_error(label, $sformatf("seq failed :assert: (False)"));
 
     initial begin
         forever begin


### PR DESCRIPTION
The first part of the throughout expression was missing a clocking event.

Example error:
```
source.sv:86:22: error: sequence has no explicit clocking event and one cannot be inferred from context
    assert property (dif.gnt2 throughout seq);
                     ^~~~~~~~
```