### PR TITLE
Blacklist invalid test from basejump

### DIFF
--- a/conf/generators/meta-path/basejump.json
+++ b/conf/generators/meta-path/basejump.json
@@ -2,9 +2,15 @@
 	"name": "BaseJumpSTL",
 	"project": "basejump",
 	"paths": [
-		["cores", "basejump_stl", "*"]
+		[
+			"cores",
+			"basejump_stl",
+			"*"
+		]
 	],
-	"matches": ["*.sv"],
+	"matches": [
+		"*.sv"
+	],
 	"commons": [
 		"cores/basejump_stl/bsg_misc/bsg_defines.sv",
 		"cores/basejump_stl/bsg_cache/bsg_cache_pkg.sv",
@@ -16,7 +22,6 @@
 		"cores/basejump_stl/bsg_tag/bsg_tag_pkg.sv",
 		"cores/basejump_stl/bsg_test/bsg_dramsim3_pkg.sv",
 		"cores/basejump_stl/bsg_axi/bsg_axi_pkg.sv"
-
 	],
 	"incdirs": [
 		"cores/basejump_stl/bsg_misc",
@@ -54,7 +59,8 @@
 		"bsg_tag_pkg.sv",
 		"bsg_test_BaseJumpSTL_bsg_nonsynth_axi_mem.sv",
 		"bsg_wormhole_router_pkg.sv",
-		"test_bsg_clock_params.sv"
+		"test_bsg_clock_params.sv",
+		"bsg_dmc_xilinx_ui_trace_replay.sv"
 	],
 	"fake_topmodule": true,
 	"results_group": "imported"


### PR DESCRIPTION
This test references an undefined macro:
```
../../../third_party/cores/basejump_stl/bsg_dmc/bsg_dmc_xilinx_ui_trace_replay.sv:22:36: error: unknown macro or compiler directive '`bsg_dmc_trace_entry_width'

                localparam trace_data_width_lp = `bsg_dmc_trace_entry_width(data_width_p, addr_width_p)

                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
Probably this file is not meant to be used standalone but as part of some other parent module when used with basejump properly as a library.