### PR TITLE
Fix permissions in `comment-pr` CI workflow

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          apt-get update -qq
-          apt install -y unzip
+          sudo apt-get update -qq
+          sudo apt install -y unzip
       - name: Download artifacts
         id: get-artifacts
         uses: actions/github-script@v7


### PR DESCRIPTION
`comment-pr` workflow fails due to lack of permissions when installing dependencies.
This is an attempt to fix it.