### PR TITLE
Fix syntax error in `comment-pr` CI workflow

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -38,7 +38,7 @@ jobs:
                archive_format: 'zip',
             });
 
-            console.log("artifact_id=" + matchArtifact.id " >> $GITHUB_OUTPUT");
+            console.log("artifact_id=" + matchArtifact.id + " >> $GITHUB_OUTPUT");
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/tests_summary.zip', Buffer.from(download.data));
 


### PR DESCRIPTION
There's a syntax error in the GitHub script in `comment-pr`. This patch fixes it.