### PR TITLE
Fix newline and other escaping in `comment-pr` CI workflow

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -62,11 +62,11 @@ jobs:
       - name: Prepare comment
         id: get-comment-body
         run: |
-          body=$(cat ./tests_summary.md)
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "body=$body" >> $GITHUB_OUTPUT
+          {
+            echo "body<<EOF"
+            cat tests_summary.md
+            echo EOF
+          } >> $GITHUB_OUTPUT
 
       - name: Get PR number
         id: get-pr-number


### PR DESCRIPTION
According to [the docs](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#multiline-strings). Hopefully it works.