### PR TITLE
Revert "Update path to `ivtest`"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,6 +52,9 @@
 [submodule "third_party/cores/rsd"]
 	path = third_party/cores/rsd
 	url = https://github.com/rsd-devel/rsd
+[submodule "third_party/tests/ivtest"]
+	path = third_party/tests/ivtest
+	url = https://github.com/steveicarus/ivtest.git
 [submodule "third_party/cores/black-parrot"]
 	path = third_party/cores/black-parrot
 	url = https://github.com/black-parrot/black-parrot

--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -26,7 +26,7 @@ scr1	SCR1 RISC-V core	https://github.com/syntacore/scr1
 taiga	Taiga RISC-V core	https://gitlab.com/sfu-rcl/Taiga
 black-parrot	BlackParrot RISC-V core	https://github.com/black-parrot/black-parrot
 rsd	RSD RISC-V core	https://github.com/rsd-devel/rsd
-ivtest	Tests imported from ivtest	https://github.com/steveicarus/iverilog/tree/master/ivtest
+ivtest	Tests imported from ivtest	https://github.com/steveicarus/ivtest
 RgGen	RgGen code generator for configuration and status registers	https://github.com/rggen/rggen
 TNoC	NoC router and fabric	https://github.com/taichi-ishitani/tnoc
 5	Lexical conventions

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -289,8 +289,7 @@ ivtest_file_exclude = [
 
 ivtest_long = ['comp1000', 'comp1001']
 
-ivtest_dir = os.path.abspath(
-    os.path.join(third_party_dir, "tools", "icarus", "ivtest"))
+ivtest_dir = os.path.abspath(os.path.join(third_party_dir, "tests", "ivtest"))
 ivtest_list_exclude = set(
     map(lambda x: os.path.join(ivtest_dir, x), ivtest_list_exclude))
 ivtest_lists = sorted(


### PR DESCRIPTION
Reverts chipsalliance/sv-tests#7303 as that broke `ivtest` for all tools other than Icarus. I'll try the fix again, properly this time.