### PR TITLE
Fix `ivtest` path, always clone `icarus`

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -148,6 +148,8 @@ jobs:
           fi
           # yosys tool contains tests, is a dependency of other tools
           git submodule update --init --recursive --depth 1 third_party/tools/yosys
+          # icarus contains tests
+          git submodule update --init --depth 1 third_party/tools/icarus
       - name: Create Cache Timestamp
         id: cache_timestamp
         uses: nanzm/get-time-action@v1.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -52,9 +52,6 @@
 [submodule "third_party/cores/rsd"]
 	path = third_party/cores/rsd
 	url = https://github.com/rsd-devel/rsd
-[submodule "third_party/tests/ivtest"]
-	path = third_party/tests/ivtest
-	url = https://github.com/steveicarus/ivtest.git
 [submodule "third_party/cores/black-parrot"]
 	path = third_party/cores/black-parrot
 	url = https://github.com/black-parrot/black-parrot

--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -26,7 +26,7 @@ scr1	SCR1 RISC-V core	https://github.com/syntacore/scr1
 taiga	Taiga RISC-V core	https://gitlab.com/sfu-rcl/Taiga
 black-parrot	BlackParrot RISC-V core	https://github.com/black-parrot/black-parrot
 rsd	RSD RISC-V core	https://github.com/rsd-devel/rsd
-ivtest	Tests imported from ivtest	https://github.com/steveicarus/ivtest
+ivtest	Tests imported from ivtest	https://github.com/steveicarus/iverilog/tree/master/ivtest
 RgGen	RgGen code generator for configuration and status registers	https://github.com/rggen/rggen
 TNoC	NoC router and fabric	https://github.com/taichi-ishitani/tnoc
 5	Lexical conventions

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -289,7 +289,8 @@ ivtest_file_exclude = [
 
 ivtest_long = ['comp1000', 'comp1001']
 
-ivtest_dir = os.path.abspath(os.path.join(third_party_dir, "tests", "ivtest"))
+ivtest_dir = os.path.abspath(
+    os.path.join(third_party_dir, "tools", "icarus", "ivtest"))
 ivtest_list_exclude = set(
     map(lambda x: os.path.join(ivtest_dir, x), ivtest_list_exclude))
 ivtest_lists = sorted(


### PR DESCRIPTION
Another attempt at fixing #7297.
This time, always clones `icarus` in CI.