### PR TITLE
Fix displaying `ivtest` tests in summary

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -244,6 +244,8 @@ jobs:
           git submodule update --init --recursive --depth 1 third_party/cores
           # yosys tool also contains tests
           git submodule update --init --recursive --depth 1 third_party/tools/yosys
+          # icarus contains tests
+          git submodule update --init --depth 1 third_party/tools/icarus
       - name: Summary
         run: |
           ./.github/workflows/summary.sh


### PR DESCRIPTION
`ivtest` (`icarus`) is not being checked out in the summary job.
Because of that, the summary doesn't display those test sources.
This fixes that by always checking out `icarus` in that job.