### PR TITLE
Fix tree-sitter-verilog exclusion from the results table

### DIFF
--- a/tools/runners.mk
+++ b/tools/runners.mk
@@ -76,12 +76,19 @@ $(INSTALL_DIR)/bin/zachjs-sv2v:
 tree-sitter-systemverilog: $(INSTALL_DIR)/bin/tree-sitter
 	(export PATH=$(INSTALL_DIR)/bin/:${PATH} && \
 		cd $(RDIR)/tree-sitter-systemverilog && tree-sitter generate)
-	cp -r $(RDIR)/tree-sitter-systemverilog/src $(abspath $(OUT_DIR)/tmp/)
+	mkdir -p $(abspath $(OUT_DIR)/tmp)
+	cp -r $(RDIR)/tree-sitter-systemverilog/src $(abspath $(OUT_DIR)/tmp/tree-sitter-systemverilog)
 
 
-tree-sitter-verilog: $(INSTALL_DIR)/bin/tree-sitter
+tree-sitter-verilog: $(INSTALL_DIR)/lib/tree-sitter-verilog.so
+
+$(INSTALL_DIR)/lib/tree-sitter-verilog.so: $(INSTALL_DIR)/bin/tree-sitter
+	mkdir -p $(INSTALL_DIR)/lib
 	(export PATH=$(INSTALL_DIR)/bin/:${PATH} && \
 		cd $(RDIR)/tree-sitter-verilog && tree-sitter generate --abi 14)
+	cd $(RDIR)/tree-sitter-verilog && \
+		gcc -fPIC -c -I./src -Os src/parser.c && \
+		gcc -fPIC -shared -Os parser.o -o $@
 
 $(INSTALL_DIR)/bin/tree-sitter:
 	wget https://github.com/tree-sitter/tree-sitter/releases/download/v0.25.3/tree-sitter-linux-x64.gz

--- a/tools/runners/tree_sitter_systemverilog.py
+++ b/tools/runners/tree_sitter_systemverilog.py
@@ -26,3 +26,10 @@ class tree_sitter_systemverilog(BaseRunner):
     def prepare_run_cb(self, tmp_dir, params):
         self.cmd = [self.executable, 'parse']
         self.cmd += params['files']
+
+    def can_run(self):
+        src_path = os.path.join(
+            os.environ.get('OUT_DIR', 'out'), 'tmp',
+            'tree-sitter-systemverilog', 'parser.c')
+
+        return os.path.exists(src_path) and super().can_run()


### PR DESCRIPTION
Fixes #7325 

Previously, `runners.mk` was only generating the parser code (`parser.c` via `tree-sitter generate`) for `tree-sitter-verilog`, without compiling it into a shared library `.so`. This prevented the Python runner for `tree-sitter-verilog` from loading the parser and executing tests, which led to the exclusion of `tree-sitter-verilog` from the results table.

The change in this PR adds compilation steps to build and install the .so file.

Additionally, in the `tree-sitter-verilog` CI job, the `tree_sitter_systemverilog` runner was invoked. This occurred because both runners use the `tree-sitter` executable, and `tools/runners/tree_sitter_systemverilog.py` didn't override `can_run()` method, which only checks for required executable by default.

This PR overrides `can_run()` in `tools/runners/tree_sitter_systemverilog.py` to verify the existence of `${OUT_DIR}/tmp/tree-sitter-systemverilog/parser.c`, required for `tree-sitter-systemverilog` to run `tree-sitter parse`.
