### PR TITLE
A few more ivtest and basejump excludes

### DIFF
--- a/conf/generators/meta-path/basejump.json
+++ b/conf/generators/meta-path/basejump.json
@@ -60,7 +60,8 @@
 		"bsg_test_BaseJumpSTL_bsg_nonsynth_axi_mem.sv",
 		"bsg_wormhole_router_pkg.sv",
 		"test_bsg_clock_params.sv",
-		"bsg_dmc_xilinx_ui_trace_replay.sv"
+		"bsg_dmc_xilinx_ui_trace_replay.sv",
+		"bsg_nonsynth_profiler.sv"
 	],
 	"fake_topmodule": true,
 	"results_group": "imported"

--- a/generators/ivtest
+++ b/generators/ivtest
@@ -369,6 +369,12 @@ ivtest_file_exclude = [
     'task_nonansi_vec2',
     # Test should expect fail: IEEE does not allow .* to connect to empty ports
     'br_gh530',
+    # The LRM does not seem to support the idea of leaking enum members out of a surrounding
+    # struct scope, though some tools support it. VCS does not.
+    'enum_in_struct',
+    # All tools allow this. The LRM contains some conflicting wording on this, but shows
+    # an example that implies it should be allowed.
+    'sv_export_fail1',
 ]
 
 ivtest_long = ['comp1000', 'comp1001']


### PR DESCRIPTION
Reasons for the two ivtest excludes are documented in the file.

The basejump exclude is due to calling a task from within a final block, which is disallowed by the LRM. Some tools error and some just warn on this.

@wsnyder @caryr 