### PR TITLE
Enable circt-verilog on Ibex and VeeR

### DIFF
--- a/conf/fusesoc-configs/ibex-sim.yml
+++ b/conf/fusesoc-configs/ibex-sim.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/ibex run --target=sim --setup lo
 conf_file: build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/lowrisc_ibex_ibex_simple_system_0.vc
 test_file: ibex-sim.sv
 timeout: 100
-compatible-runners: verilator slang
+compatible-runners: verilator slang circt-verilog
 type: parsing elaboration simulation_without_run

--- a/conf/fusesoc-configs/ibex-synth.yml
+++ b/conf/fusesoc-configs/ibex-synth.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/ibex run --target=synth --setup 
 conf_file: build/lowrisc_ibex_top_artya7_0.1/synth-vivado/lowrisc_ibex_top_artya7_0.1.tcl
 test_file: ibex-synth.sv
 timeout: 100
-compatible-runners: yosys-synlig yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse
+compatible-runners: yosys-synlig yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse circt-verilog
 type: parsing elaboration

--- a/conf/fusesoc-configs/veer-eh1-sim.yml
+++ b/conf/fusesoc-configs/veer-eh1-sim.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/veer-eh1 run --target=sim --setu
 conf_file: build/veer-eh1_sim/sim-verilator/chipsalliance.org_cores_VeeR_EH1_1.8.vc
 test_file: veer-eh1-sim.sv
 timeout: 180
-compatible-runners: verilator slang
+compatible-runners: verilator slang circt-verilog
 type: parsing elaboration simulation_without_run

--- a/conf/fusesoc-configs/veer-eh1-synth.yml
+++ b/conf/fusesoc-configs/veer-eh1-synth.yml
@@ -16,5 +16,5 @@ command: fusesoc --cores-root third_party/cores/veer-eh1 run --target=synth --se
 conf_file: build/veer-eh1_synth/synth-vivado/chipsalliance.org_cores_VeeR_EH1_1.8.tcl
 test_file: veer-eh1-synth.sv
 timeout: 180
-compatible-runners: yosys-synlig yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse
+compatible-runners: yosys-synlig yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse circt-verilog
 type: parsing elaboration


### PR DESCRIPTION
Add circt-verilog as a compatible runner to the fusesoc config for the Ibex and VeeR cores.