### PR TITLE
Tests: Fix 16.15--property-disable-iff-fail.sv to have correct :assert:

### DIFF
--- a/tests/chapter-16/16.15--property-disable-iff-fail.sv
+++ b/tests/chapter-16/16.15--property-disable-iff-fail.sv
@@ -52,7 +52,7 @@ module top();
         @(posedge clk) disable iff (~rst) out;
     endproperty
 
-    assert property (prop) else $error($sformatf("property check failed :assert: (False)"));
+    assert property (prop) else $error($sformatf("property check failed :assert: (True)"));
 
     initial begin
         forever begin


### PR DESCRIPTION
16.15--property-disable-iff-fail printed a backwards `:assert:` so this was failing incorrectly only on simulator tools, due to parseLog not matching the `:assert:`