### PR TITLE
Tests: Disable Ivtests br_gh1175f

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -375,6 +375,9 @@ ivtest_file_exclude = [
     # All tools allow this. The LRM contains some conflicting wording on this, but shows
     # an example that implies it should be allowed.
     'sv_export_fail1',
+    # Redefining the same UDP is above what IEEE specifies; it's an error on some tools,
+    # warning on others (which pick first or last defined), and ignored on yet others.
+    'br_gh1175f',
 ]
 
 ivtest_long = ['comp1000', 'comp1001']


### PR DESCRIPTION
Disables br_gh1175f, which redefines a UDP by the same name.

Behavior of multiple definitions of primitives/modules is outside IEEE and depends on library handling.

Icarus and one closed-source simulator error (which this test required).
Three closed-source simulators warned (false-failing this test as return good edit status).
Two closed-source simulators silently accepted (false-failing this test as return good edit status).
