### PR TITLE
Update Verilator runner to disable UVM DPI, and use --binary jobs

### DIFF
--- a/tools/BaseRunner.py
+++ b/tools/BaseRunner.py
@@ -140,7 +140,7 @@ class BaseRunner:
             kill_child_processes(proc.pid)
             proc.kill()
             proc.communicate()
-            log = ("Timeout: > " + str(timeout) + "s").encode('utf-8')
+            log = ("Timeout: > " + str(timeout) + "s\n").encode('utf-8')
             returncode = 71  # 71meout :) - something easy to grep for
 
         invocation_log = " ".join(self.cmd) + "\n"


### PR DESCRIPTION
This updates the Verilator runner to not compile the UVM DPI (see comments), use --binary, and use parallel builds.

Without parallel builds many UVM tests time out in 30 seconds, with I think more will pass (we'll see).
