### PR TITLE
For Verilator, use lower -j due to UVM tests etc

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -40,6 +40,7 @@ jobs:
             skip-ccache: 1
           - name: verilator
             deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev
+            make_jobs_max: 4
           - name: yosys
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev
           - name: yosys-synlig
@@ -182,8 +183,10 @@ jobs:
           BIG_GENERATORS_EXPR=$(echo $BIG_GENERATORS | sed 's/ /\\|/g')
           export STABLE_GENERATORS=$(make list-generators | tr ' ' '\n' | grep -v "${BIG_GENERATORS_EXPR}")
           export UNSTABLE_GENERATORS=$(make list-generators | tr ' ' '\n' | grep "${BIG_GENERATORS_EXPR}")
-          for gen in ${STABLE_GENERATORS}; do make generate-$gen -j$(nproc); make -j$(nproc); done
-          for gen in ${UNSTABLE_GENERATORS}; do make generate-$gen; make; done
+          export JOBS=${{ matrix.tool.make_jobs_max }}
+          if [[ "${JOBS}x" == "x" ]]; then export JOBS=$(nproc); fi
+          for gen in ${STABLE_GENERATORS}; do echo "==GEN stable $gen -j $JOBS" ; make generate-$gen -j${JOBS}; make -j ${JOBS}; done
+          for gen in ${UNSTABLE_GENERATORS}; do echo "==GEN unstable $gen" ; make generate-$gen; make; done
       - name: Prepare Report
         run:
           mv out/report/report.csv out/report/${{ matrix.tool.name }}_report.csv

--- a/conf/generators/templates/uvm-classes_0.sv
+++ b/conf/generators/templates/uvm-classes_0.sv
@@ -12,6 +12,7 @@
 :description: {0} class test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/conf/generators/templates/uvm-classes_1.sv
+++ b/conf/generators/templates/uvm-classes_1.sv
@@ -12,6 +12,7 @@
 :description: {0} class test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/conf/generators/templates/uvm-classes_2.json
+++ b/conf/generators/templates/uvm-classes_2.json
@@ -7,6 +7,7 @@
 		":description: {0} class test",
 		":tags: uvm uvm-classes",
 		":type: parsing",
+		":timeout: 300",
 		"*/",
 		"import uvm_pkg::*;",
 		"`include \"uvm_macros.svh\"\n",

--- a/conf/generators/templates/uvm-classes_3.sv
+++ b/conf/generators/templates/uvm-classes_3.sv
@@ -12,6 +12,7 @@
 :description: {0} class test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/generators/easyUVM
+++ b/generators/easyUVM
@@ -19,7 +19,7 @@ templ = """/*
 :files: {0}
 :incdirs: {1}
 :tags: uvm
-:timeout: 100
+:timeout: 300
 :unsynthesizable: 1
 */
 """

--- a/tests/chapter-16/16.10--property-local-var-uvm.sv
+++ b/tests/chapter-16/16.10--property-local-var-uvm.sv
@@ -12,7 +12,7 @@
 :description: property with local variables in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.10--sequence-local-var-uvm.sv
+++ b/tests/chapter-16/16.10--sequence-local-var-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with local variables in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.11--sequence-subroutine-uvm.sv
+++ b/tests/chapter-16/16.11--sequence-subroutine-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with subroutine in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.12--property-interface-prec-uvm.sv
+++ b/tests/chapter-16/16.12--property-interface-prec-uvm.sv
@@ -12,7 +12,7 @@
 :description: interface property with precondition in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.12--property-interface-uvm.sv
+++ b/tests/chapter-16/16.12--property-interface-uvm.sv
@@ -12,7 +12,7 @@
 :description: interface property test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.12--property-prec-uvm.sv
+++ b/tests/chapter-16/16.12--property-prec-uvm.sv
@@ -12,7 +12,7 @@
 :description: property with precondition in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.12--property-uvm.sv
+++ b/tests/chapter-16/16.12--property-uvm.sv
@@ -12,7 +12,7 @@
 :description: property test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.13--sequence-multiclock-uvm.sv
+++ b/tests/chapter-16/16.13--sequence-multiclock-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with local variables in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.14--assume-property-uvm.sv
+++ b/tests/chapter-16/16.14--assume-property-uvm.sv
@@ -12,7 +12,7 @@
 :description: assume property test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.15--property-iff-uvm.sv
+++ b/tests/chapter-16/16.15--property-iff-uvm.sv
@@ -12,7 +12,7 @@
 :description: property with disable iff test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.17--expect-uvm.sv
+++ b/tests/chapter-16/16.17--expect-uvm.sv
@@ -12,7 +12,7 @@
 :description: expect in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.2--assert-final-uvm.sv
+++ b/tests/chapter-16/16.2--assert-final-uvm.sv
@@ -12,7 +12,7 @@
 :description: assert final test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.2--assert-uvm.sv
+++ b/tests/chapter-16/16.2--assert-uvm.sv
@@ -12,7 +12,7 @@
 :description: assert test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.2--assert0-uvm.sv
+++ b/tests/chapter-16/16.2--assert0-uvm.sv
@@ -12,7 +12,7 @@
 :description: assert0 test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.2--assume-uvm.sv
+++ b/tests/chapter-16/16.2--assume-uvm.sv
@@ -12,7 +12,7 @@
 :description: assert test with UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.7--sequence-and-range-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-and-range-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with range and "and" operator in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.7--sequence-and-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-and-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "and" operator in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.7--sequence-intersect-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-intersect-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "intersect" operator in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.7--sequence-or-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-or-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "or" operator in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.7--sequence-throughout-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-throughout-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "throughout" operator in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.7--sequence-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.9--sequence-changed-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-changed-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "changed" task in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.9--sequence-fell-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-fell-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "fell" task in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.9--sequence-past-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-past-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "past" task in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.9--sequence-rose-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-rose-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "rose" task in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/chapter-16/16.9--sequence-stable-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-stable-uvm.sv
@@ -12,7 +12,7 @@
 :description: sequence with "stable" task in UVM
 :type: simulation elaboration parsing
 :tags: uvm uvm-assertions
-:timeout: 60
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_agent_env.sv
+++ b/tests/testbenches/uvm_agent_env.sv
@@ -12,7 +12,7 @@
 :description: uvm agent + env test
 :tags: uvm uvm-agents
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_agent_passive.sv
+++ b/tests/testbenches/uvm_agent_passive.sv
@@ -12,7 +12,7 @@
 :description: passive uvm_agent (agent + monitor + env) test
 :tags: uvm uvm-agents
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_driver_sequencer_env.sv
+++ b/tests/testbenches/uvm_driver_sequencer_env.sv
@@ -12,7 +12,7 @@
 :description: uvm driver + sequencer + env test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_monitor_env.sv
+++ b/tests/testbenches/uvm_monitor_env.sv
@@ -12,7 +12,7 @@
 :description: uvm monitor + env test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_resource_db_read_by_name.sv
+++ b/tests/testbenches/uvm_resource_db_read_by_name.sv
@@ -12,6 +12,7 @@
 :description: uvm resource_db::read_by_name test
 :tags: uvm
 :type: simulation elaboration parsing
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_scoreboard_env.sv
+++ b/tests/testbenches/uvm_scoreboard_env.sv
@@ -12,7 +12,7 @@
 :description: uvm scoreboard + env test
 :tags: uvm uvm-scoreboards
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_scoreboard_monitor_agent_env.sv
+++ b/tests/testbenches/uvm_scoreboard_monitor_agent_env.sv
@@ -12,7 +12,7 @@
 :description: uvm scoreboard + monitor + agent + env test
 :tags: uvm uvm-scoreboards
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_scoreboard_monitor_env.sv
+++ b/tests/testbenches/uvm_scoreboard_monitor_env.sv
@@ -12,7 +12,7 @@
 :description: uvm scoreboard + monitor + env test
 :tags: uvm uvm-scoreboards
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_sequence.sv
+++ b/tests/testbenches/uvm_sequence.sv
@@ -12,6 +12,7 @@
 :description: uvm_sequence test
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/testbenches/uvm_test_run_test.sv
+++ b/tests/testbenches/uvm_test_run_test.sv
@@ -12,6 +12,7 @@
 :description: test if uvm_test instance can be called by name
 :tags: uvm uvm-classes
 :type: simulation elaboration parsing
+:timeout: 300
 :unsynthesizable: 1
 */
 


### PR DESCRIPTION
The UVM tests are timing out, this sets up less top parallelism to leave more CPUs free for Verilator to parallelize its build on.

Draft as might need tweaking or a straight timeout increase.
