### PR TITLE
Fix more UVM timeouts

### DIFF
--- a/tests/testbenches/uvm_agent_active.sv
+++ b/tests/testbenches/uvm_agent_active.sv
@@ -12,7 +12,7 @@
 :description: uvm active agent (agent + monitor + driver + sequencer) test
 :tags: uvm uvm-agents
 :type: simulation elaboration parsing
-:timeout: 30
+:timeout: 300
 :unsynthesizable: 1
 */
 

--- a/tests/uvm/uvm_files.sv
+++ b/tests/uvm/uvm_files.sv
@@ -11,7 +11,7 @@
 :name: uvm_files
 :description: basic UVM test
 :tags: uvm
-:timeout: 100
+:timeout: 300
 :unsynthesizable: 1
 */
 


### PR DESCRIPTION
Missed two timeout increases.  uvm_agent_active.sv will pass with this.  uvm_files already passed but wanted to match other timeouts.

@kbieganski thanks!

