### PR TITLE
Add ivtest_extra_args for tool specific flags

### DIFF
--- a/generators/ivtest
+++ b/generators/ivtest
@@ -385,6 +385,7 @@ ivtest_extra_args = {
     'comp1000': ':timeout: 360',
     'comp1001': ':timeout: 360',
     # Promote warning to error to match iverilog
+    'porttest3': ':runner_verilator_flags: -Werror-ASSIGNIN',
     'pr1909940': ':runner_verilator_flags: -Werror-IMPLICIT',
     'pr1909940b': ':runner_verilator_flags: -Werror-IMPLICIT'
 }


### PR DESCRIPTION
Adds for ivtest generators an ivtest_extra_args to allow arbitrary test parameters.
1. Move timeout changes to this more generic feature.
2. Add flags to two tests so that Verilator warnings become errors to match icarus.
