### PR TITLE
chore: temporarily disable treesitter

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -33,6 +33,7 @@ jobs:
             rust_ver: "1.81"
 # Temporary disabled to sidestep an out-of-diskspace issue. Should be disabled after
 # we found a way to reduce the logsize of the tree-sitter builds.
+# See https://github.com/chipsalliance/sv-tests/issues/7688 for details.
 #          - name: tree-sitter-systemverilog
 #            deps: gcc
 #          - name: tree-sitter-verilog


### PR DESCRIPTION
We currently do not get any build results published due to issues with the logfile size: https://github.com/chipsalliance/sv-tests/issues/7688.

This change disables treesitter to restore result-updates until the treesitter log size has been reduced.