### PR TITLE
Reduce tree-sitter log sizes using --quiet flag (#7688)

### DIFF
--- a/tools/runners/tree_sitter_systemverilog.py
+++ b/tools/runners/tree_sitter_systemverilog.py
@@ -32,7 +32,7 @@ class tree_sitter_systemverilog(BaseRunner):
         if os.path.exists(symlink_path) is False:
             os.symlink(self.parser_dir, symlink_path, True)
 
-        self.cmd = [self.executable, 'parse']
+        self.cmd = [self.executable, 'parse', '--quiet']
         self.cmd += params['files']
 
     def can_run(self):

--- a/tools/runners/tree_sitter_verilog.py
+++ b/tools/runners/tree_sitter_verilog.py
@@ -31,7 +31,7 @@ class tree_sitter_verilog(BaseRunner):
         if os.path.exists(symlink_path) is False:
             os.symlink(self.parser_dir, symlink_path, True)
 
-        self.cmd = [self.executable, 'parse']
+        self.cmd = [self.executable, 'parse', '--quiet']
         self.cmd += params['files']
 
     def can_run(self):


### PR DESCRIPTION
Fixes #7688 by adding `--quiet` flag to `tree-sitter parse` command in both `tree_sitter_systemverilog` and `tree_sitter_verilog` runners.

This reduces log output by suppressing parser output while maintaining correct test pass/fail detection.
Error messages and line information are preserved in the logs.
