### PR TITLE
[IBEX][FuseSoC] Fix IBEX fusesoc config

### DIFF
--- a/conf/fusesoc-configs/ibex-sim.yml
+++ b/conf/fusesoc-configs/ibex-sim.yml
@@ -12,7 +12,7 @@ description: Full ibex core test
 top_module: ibex_simple_system
 tags: ibex
 path: third_party/cores/ibex
-command: fusesoc --cores-root third_party/cores/ibex run --target=sim --setup lowrisc:ibex:ibex_simple_system --RV32E=0 --RV32M=ibex_pkg::RV32MFast
+command: fusesoc --cores-root third_party/cores/ibex run --target=sim --setup --mapping lowrisc:prim_generic:all:0.1 lowrisc:ibex:ibex_simple_system --RV32E=0 --RV32M=ibex_pkg::RV32MFast
 conf_file: build/lowrisc_ibex_ibex_simple_system_0/sim-verilator/lowrisc_ibex_ibex_simple_system_0.vc
 test_file: ibex-sim.sv
 timeout: 100

--- a/conf/fusesoc-configs/veer-eh1-sim.yml
+++ b/conf/fusesoc-configs/veer-eh1-sim.yml
@@ -13,7 +13,7 @@ top_module: tb_top
 tags: veer-eh1
 path: third_party/cores/veer-eh1
 command: fusesoc --cores-root third_party/cores/veer-eh1 run --target=sim --setup --build-root build/veer-eh1_sim chipsalliance.org:cores:VeeR_EH1:1.8
-conf_file: build/veer-eh1_sim/sim-verilator/chipsalliance.org_cores_VeeR_EH1_1.8.vc
+conf_file: build/veer-eh1_sim/chipsalliance.org_cores_VeeR_EH1_1.8/sim-verilator/chipsalliance.org_cores_VeeR_EH1_1.8.vc
 test_file: veer-eh1-sim.sv
 timeout: 180
 compatible-runners: verilator slang circt-verilog

--- a/conf/fusesoc-configs/veer-eh1-synth.yml
+++ b/conf/fusesoc-configs/veer-eh1-synth.yml
@@ -13,7 +13,7 @@ top_module: veer-eh1_wrapper
 tags: veer-eh1
 path: third_party/cores/veer-eh1
 command: fusesoc --cores-root third_party/cores/veer-eh1 run --target=synth --setup --build-root build/veer-eh1_synth chipsalliance.org:cores:VeeR_EH1:1.8
-conf_file: build/veer-eh1_synth/synth-vivado/chipsalliance.org_cores_VeeR_EH1_1.8.tcl
+conf_file: build/veer-eh1_synth/chipsalliance.org_cores_VeeR_EH1_1.8/synth-vivado/chipsalliance.org_cores_VeeR_EH1_1.8.tcl
 test_file: veer-eh1-synth.sv
 timeout: 180
 compatible-runners: yosys-synlig yosys yosys-sv zachjs-sv2v icarus moore moore-parse odin sv-parser tree-sitter-verilog verible verible_extractor Surelog slang-parse circt-verilog

--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -9,7 +9,7 @@ make_var
 markupsafe
 pytablewriter
 GitPython
-simplesat==0.8.2
-git+https://github.com/lowRISC/edalize.git@ot
-git+https://github.com/lowRISC/fusesoc.git@ot
+simplesat==0.9.1
+edalize==0.6.1
+fusesoc==2.4.3
 orderedmultidict


### PR DESCRIPTION
First time contributor, please let me know if I missed any contribution guidelines or similar - happy to invest reasonable effort to adjust this PR.

As explained in [the lowRisc documentation](https://opentitan.org/book/hw/ip/prim/index.html#mappings), the `lowrisc:prim` library is virtual, and should be mapped via the CLI. Currently, no mapping is passed, and all potential `lowrisc:prim` candidates are added to the elaboration flow; this causes warnings in `verilator`, and errors in `circt-verilog`, since it leads to module definition duplication.

This PR fixes this issue by choosing the de-facto correct mapping of `prim_generic`, since `prim_xilinx` would require external dependencies that are currently not mapped.