### PR TITLE
Fix tests/chapter-16/16.10--property-local-var-fail.sv on simulators

### DIFF
--- a/tests/chapter-16/16.10--property-local-var-fail.sv
+++ b/tests/chapter-16/16.10--property-local-var-fail.sv
@@ -66,7 +66,7 @@ module top();
         @(posedge clk) (valid, x = in) |-> ##4 (out == x + 3);
     endproperty
 
-    assert property (prop) else $error($sformatf("property check failed :assert: (False)"));
+    assert property (prop) else $error($sformatf("property check failed :assert: (True)"));
 
     assign in = cycle;
 


### PR DESCRIPTION
property_local_var_fail had a backwards ":assert:" causing it to fail on simulators that properly asserted.

@kbieganski please merge once tests pass thanks.
