### PR TITLE
Add uvm examples tests

### DIFF
--- a/.github/workflows/sv-tests-code-quality.yml
+++ b/.github/workflows/sv-tests-code-quality.yml
@@ -39,6 +39,4 @@ jobs:
             ./third_party/cores/
             ./third_party/tests/
             ./third_party/tools/
-          exclude_license: |
-            ./third_party/tests/uvm-examples
 

--- a/.github/workflows/sv-tests-code-quality.yml
+++ b/.github/workflows/sv-tests-code-quality.yml
@@ -39,4 +39,6 @@ jobs:
             ./third_party/cores/
             ./third_party/tests/
             ./third_party/tools/
+          exclude_license: |
+            ./third_party/tests/uvm-examples
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -99,3 +99,6 @@
 [submodule "third_party/tools/verilator"]
 	path = third_party/tools/verilator
 	url = https://github.com/verilator/verilator
+[submodule "third_party/tests/uvm-examples"]
+	path = third_party/tests/uvm-examples
+	url = https://github.com/antmicro/uvm-examples.git

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ After creating a new test case it must be correctly tagged:
 * `top_module` - optional, allows to specify which module is the top one.
 * `tags` - tag must be used to specify which part of SystemVerilog specification this test case covers.
 * `defines` - provides a list of macros for preprocessor.
+* `simvariants` - optional, a list to run a simulation multiple times, each with a different argument.
+
   If the test case uses several SystemVerilog features, only the feature directly tested should be included in tags.
   List of existing tags is located in `conf/lrm.conf`.
 

--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -20,6 +20,7 @@ uvm-assertions	UVM tests using assertions
 uvm-scoreboards	uvm_scoreboard examples
 uvm-agents	uvm_agent examples
 uvm-classes	Particular UVM classes
+uvm-examples	UVM examples
 basejump	Tests imported from Basejump STL	https://github.com/bespoke-silicon-group/basejump_stl
 ariane	Ariane RISC-V core	https://github.com/openhwgroup/cva6
 scr1	SCR1 RISC-V core	https://github.com/syntacore/scr1

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -18,9 +18,11 @@ templ = """/*
 :description: UVM example - {name}
 :files: {0}
 :incdirs: {1}
-:defines: {2}
 :tags: uvm-examples uvm
+:type: simulation elaboration parsing
 :timeout: 360
+:unsynthesizable: 1
+:simargs: {2}
 */
 """
 
@@ -44,12 +46,12 @@ tests = {
     "apb_protocol_monitor": {
         "files": "protocol_monitor/apb_monitor.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "",
     },
     "biquad_example": {
         "files": "tb/agents/signal_agent/signal_if.sv tb/agents/apb_agent/apb_if.sv tb/agents/apb_agent/apb_agent_pkg.sv tb/agents/signal_agent/signal_agent_pkg.sv",
         "incdirs": "tb/agents/apb_agent tb/agents/signal_agent",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=biquad_smoke_test",
     },
     "uart_example": {
         "files": "rtl/uart/uart_16550.sv  rtl/uart/uart_register_file.sv rtl/uart/uart_rx_fifo.sv  rtl/uart/uart_rx.sv  rtl/uart/uart_tx_fifo.sv  rtl/uart/uart_tx.sv \
@@ -69,12 +71,12 @@ tests = {
             uvm_tb/sequences \
             uvm_tb/virtual_sequences \
             uvm_tb/tests",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=uart_test",
     },
     "uvm_ac_config_db": {
         "files": "sfr_agent/sfr_agent_pkg.sv sfr_agent/sfr_master_bfm.sv sfr_agent/sfr_monitor_bfm.sv sfr_test_pkg/sfr_test_pkg.sv tb/hdl_top.sv  tb/hvl_top.sv rtl/sfr_dut.sv",
         "incdirs": "sfr_agent sfr_test_pkg",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=sfr_test",
     },
     "uvm_alu_config_analysis": {
         "files": "agent/alu_agent_pkg.sv \
@@ -84,7 +86,7 @@ tests = {
             uvm_tb/alu_tb_pkg.sv \
             tb/hdl_top.sv  tb/hvl_top.sv",
         "incdirs": "agent uvm_tb",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=test_all_parallel",
     },
     "uvm_c_stimulus_bl_example": {
         "files": "./c_stimulus_pkg/c_stimulus_pkg.sv \
@@ -118,7 +120,7 @@ tests = {
             block_level_example/uvm_tb/sequences \
             block_level_example/uvm_tb/test \
             block_level_example/c_code",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=spi_c_int_test",
     },
     "uvm_ef_vif_config_db": {
         "files": "./sfr_agent/sfr_agent_pkg.sv \
@@ -129,7 +131,7 @@ tests = {
             ./tb/hdl_top.sv \
             ./rtl/sfr_dut.sv",
         "incdirs": "sfr_agent sfr_test_pkg",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=sfr_test",
     },
     "uvm_generation_seq_persistence": {
         "files": "./common/bus_if.sv \
@@ -139,7 +141,7 @@ tests = {
             ./tests/test_lib_pkg.sv \
             ./common/top_tb.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=complete_transfer_test",
     },
     "uvm_generation_seq_poly": {
         "files": "./common/bus_if.sv \
@@ -149,7 +151,7 @@ tests = {
             ./tests/test_lib_pkg.sv \
             ./common/top_tb.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=rand_transfer_test",
     },
     "uvm_generation_seq_randomization": {
         "files": "common/bus_if.sv \
@@ -159,13 +161,13 @@ tests = {
             tests/test_lib_pkg.sv \
             common/top_tb.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=seq_rand_test",
     },
     "uvm_id_register": {
         "files": "apb_agent/apb_agent_pkg.sv apb_agent/apb_driver_bfm.sv apb_agent/apb_monitor_bfm.sv \
         reg_dut.sv regmodel_pkg.sv uvm_tb_pkg.sv hvl_top.sv hdl_top.sv",
         "incdirs": "apb_agent",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_interrupts_parallel_processing": {
         "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
@@ -174,19 +176,19 @@ tests = {
             parallel_processing/dsp_con_driver_bfm.sv \
             parallel_processing/top.sv",
         "incdirs": "utils/interrupt parallel_processing",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_interrupts_prioritized": {
         "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
             bidirect_bus_agent_pkg.sv prioritised/top.sv",
         "incdirs": "utils/interrupt",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_interrupts_simple": {
         "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
             bidirect_bus_agent_pkg.sv simple/top.sv",
         "incdirs": "utils/interrupt",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_many_to_one": {
         "files": "./b.sv \
@@ -196,17 +198,17 @@ tests = {
             ./env.sv \
             ./test.sv",
         "incdirs": ".",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=test",
     },
     "uvm_messaging_example": {
         "files": "messaging_example.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=message_test",
     },
     "uvm_overriding": {
         "files": "a_agent_pkg.sv top.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_param_vif_config_db": {
         "files": "./sfr_agent/sfr_agent_pkg.sv \
@@ -218,17 +220,17 @@ tests = {
             ./tb/hvl_top.sv \
             ./rtl/sfr_dut.sv",
         "incdirs": "sfr_agent sfr_test_pkg",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=sfr_test",
     },
     "uvm_priority_arbitration": {
         "files": "top.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "ARB_TYPE=SEQ_ARB_FIFO",
     },
     "uvm_priority_grab_lock": {
         "files": "top.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "ARB_TYPE=SEQ_ARB_FIFO",
     },
     "uvm_register_mem_example": {
         "files": "./dut/timescale.v ./dut/mem_ss.sv ./dut/reg_defs.sv \
@@ -243,7 +245,7 @@ tests = {
             ./tb/hvl_top.sv \
             ./tb/hdl_top.sv",
         "incdirs": "dut agents/ahb_agent register_model env sequences test utils",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=mem_ss_test",
     },
     "uvm_register_spi_bl_tb": {
         "files": "./rtl/spi/rtl/verilog/spi_clgen.v \
@@ -273,7 +275,7 @@ tests = {
         block_level_tbs/spi_tb/env \
         block_level_tbs/spi_tb/sequences \
         block_level_tbs/spi_tb/test",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=spi_interrupt_test",
     },
     "uvm_slave_agent": {
         "files": "agents/apb_slave_agent/apb_slave_agent_pkg.sv \
@@ -285,7 +287,7 @@ tests = {
             ./tb/hvl_top.sv \
             ./tb/hdl_top.sv",
         "incdirs": "agents/apb_slave_agent tb",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_slave_agent_multi_seq_item": {
         "files": "./agents/apb_slave_agent/apb_if.sv \
@@ -294,7 +296,7 @@ tests = {
             ./rtl/apb3_wlm_host.sv \
             ./tb/env_pkg.sv ./tb/hdl_top.sv ./tb/hvl_top.sv",
         "incdirs": "agents/apb_slave_agent tb",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_tb_build_bl_tb": {
         "files": "./rtl/spi/rtl/verilog/spi_clgen.v \
@@ -329,7 +331,7 @@ tests = {
             rtl/spi/rtl/verilog \
             utils \
             utils/interrupt",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=spi_interrupt_test",
     },
     "uvm_tb_build_ss_tb": {
         "files": "sub_system_tbs/pss_tb/tb/hdl_top.sv \
@@ -399,7 +401,7 @@ tests = {
             sub_system_tbs/pss_tb/env \
             block_level_tbs/spi_tb/sequences \
             block_level_tbs/gpio_tb/sequences",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=pss_spi_interrupt_test",
     },
     "uvm_test_init": {
         "files": "agent_a_pkg.sv \
@@ -411,17 +413,17 @@ tests = {
             top_vseq_pkg.sv \
             top.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=init_vseq_from_test",
     },
     "uvm_use_models_bidir_get_put": {
         "files": "top_tb.sv top_hdl.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_use_models_bidir_item_done": {
         "files": "top_tb.sv top_hdl.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_use_models_pipelined_get_put": {
         "files": "mbus_slave/mbus_types_pkg.sv \
@@ -430,19 +432,19 @@ tests = {
         pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_driver_bfm.sv \
         pipelined_get_put/top_tb.sv pipelined_get_put/top_hdl.sv",
         "incdirs": "pipelined_get_put/mbus_pipelined_agent",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_use_models_pipelined_item_done": {
         "files": "./mbus_slave/mbus_slave.sv \
             ./pipelined_item_done/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv \
             ./pipelined_item_done/top.sv",
         "incdirs": "pipelined_item_done/mbus_pipelined_agent",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_use_models_unidirectional": {
         "files": "top_tb.sv top_hdl.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_vif_config_db": {
         "files": "sfr_agent/sfr_agent_pkg.sv \
@@ -452,17 +454,17 @@ tests = {
             tb/hvl_top.sv \
             rtl/sfr_dut.sv",
         "incdirs": "sfr_agent sfr_test_pkg",
-        "defines": "",
+        "simargs": "UVM_TESTNAME=sfr_test",
     },
     "uvm_virt_seq_find_all": {
         "files": "simple_ovc/simple_pkg.sv top.sv",
         "incdirs": "simple_ovc",
-        "defines": "",
+        "simargs": "",
     },
     "uvm_wait_for_signal": {
         "files": "bus_if.sv bidirect_bus_pkg.sv bidirect_bus_driver_bfm.sv top.sv",
         "incdirs": "",
-        "defines": "",
+        "simargs": "",
     },
 }
 
@@ -476,5 +478,6 @@ for dir in os.scandir(examples_path):
     test_file = os.path.join(test_dir, dir.name + ".sv")
     files = [os.path.join(examples_path, test_name, name) for name in test["files"].split()]
     incdirs = [os.path.join(examples_path, test_name, name) for name in test["incdirs"].split()]
+    print(test["simargs"])
     with open(test_file, "w") as f:
-        f.write(templ.format(" ".join(files), " ".join(incdirs), test["defines"], name=dir.name))
+        f.write(templ.format(" ".join(files), " ".join(incdirs), test["simargs"], name=dir.name))

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2026 The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier: ISC
+
+import sys
+import os
+import glob
+
+templ = """/*
+:name: {name}
+:description: UVM example - {name}
+:files: {0}
+:incdirs: {1}
+:defines: {2}
+:tags: uvm-examples uvm
+:timeout: 360
+*/
+"""
+
+try:
+    third_party_dir = os.environ['THIRD_PARTY_DIR']
+    tests_dir = os.environ['TESTS_DIR']
+except KeyError:
+    print("Export the THIRD_PARTY_DIR and TESTS_DIR variables first")
+    sys.exit(1)
+
+try:
+    tests_subdir = sys.argv[1]
+except IndexError:
+    print("Usage: ./generator <subdir>")
+    sys.exit(1)
+
+examples_path = os.path.abspath(os.path.join(third_party_dir, "tests", "uvm-examples"))
+main_path = os.path.abspath(os.getcwd())
+
+tests = {
+    "apb_protocol_monitor": {
+        "files": "protocol_monitor/apb_monitor.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "biquad_example": {
+        "files": "tb/agents/signal_agent/signal_if.sv tb/agents/apb_agent/apb_if.sv tb/agents/apb_agent/apb_agent_pkg.sv tb/agents/signal_agent/signal_agent_pkg.sv",
+        "incdirs": "tb/agents/apb_agent tb/agents/signal_agent",
+        "defines": "",
+    },
+    "uart_example": {
+        "files": "rtl/uart/uart_16550.sv  rtl/uart/uart_register_file.sv rtl/uart/uart_rx_fifo.sv  rtl/uart/uart_rx.sv  rtl/uart/uart_tx_fifo.sv  rtl/uart/uart_tx.sv \
+            agents/apb_agent/apb_if.sv agents/apb_agent/apb_agent_pkg.sv agents/uart_agent/serial_if.sv agents/uart_agent/uart_agent_pkg.sv agents/modem_agent/modem_if.sv agents/modem_agent/modem_agent_pkg.sv \
+            uvm_tb/register_model/uart_reg_pkg.sv \
+            uvm_tb/env/uart_env_pkg.sv \
+            uvm_tb/sequences/host_if_seq_pkg.sv \
+            uvm_tb/sequences/uart_seq_pkg.sv \
+            uvm_tb/virtual_sequences/uart_vseq_pkg.sv \
+            uvm_tb/tests/uart_test_pkg.sv \
+            uvm_tb/tb/interrupt_if.sv \
+            protocol_monitor/apb_monitor.sv \
+            uvm_tb/tb/uart_tb.sv",
+        "incdirs": "agents/apb_agent agents/uart_agent \
+            uvm_tb/env \
+            uvm_tb/sequences \
+            uvm_tb/sequences \
+            uvm_tb/virtual_sequences \
+            uvm_tb/tests",
+        "defines": "",
+    },
+    "uvm_ac_config_db": {
+        "files": "sfr_agent/sfr_agent_pkg.sv sfr_agent/sfr_master_bfm.sv sfr_agent/sfr_monitor_bfm.sv sfr_test_pkg/sfr_test_pkg.sv tb/hdl_top.sv  tb/hvl_top.sv rtl/sfr_dut.sv",
+        "incdirs": "sfr_agent sfr_test_pkg",
+        "defines": "",
+    },
+    "uvm_alu_config_analysis": {
+        "files": "agent/alu_agent_pkg.sv \
+            agent/alu_monitor_bfm.sv \
+            agent/alu_driver_bfm.sv \
+            alu/alu_if.sv  alu/alu_rtl.sv\
+            uvm_tb/alu_tb_pkg.sv \
+            tb/hdl_top.sv  tb/hvl_top.sv",
+        "incdirs": "agent uvm_tb",
+        "defines": "",
+    },
+    "uvm_c_stimulus_bl_example": {
+        "files": "./c_stimulus_pkg/c_stimulus_pkg.sv \
+            ./c_stimulus_pkg/isr_pkg.sv \
+            ./block_level_example/rtl/spi/rtl/verilog/spi_clgen.v \
+            ./block_level_example/rtl/spi/rtl/verilog/timescale.v \
+            ./block_level_example/rtl/spi/rtl/verilog/spi_defines.v \
+            ./block_level_example/rtl/spi/rtl/verilog/spi_shift.v \
+            ./block_level_example/rtl/spi/rtl/verilog/spi_top.v \
+            ./block_level_example/agents/apb_agent/apb_agent_pkg.sv \
+            ./block_level_example/agents/spi_agent/spi_agent_pkg.sv \
+            ./block_level_example/uvm_tb/uvm_register_model/spi_reg_pkg.sv \
+            ./block_level_example/agents/apb_agent/apb_if.sv \
+            ./block_level_example/agents/spi_agent/spi_if.sv \
+            ./block_level_example/uvm_tb/tb/intr_if.sv \
+            ./block_level_example/uvm_tb/env/spi_env_pkg.sv \
+            ./block_level_example/uvm_tb/sequences/spi_bus_sequence_lib_pkg.sv \
+            ./block_level_example/uvm_tb/sequences/spi_sequence_lib_pkg.sv \
+            ./block_level_example/uvm_tb/sequences/spi_virtual_seq_lib_pkg.sv \
+            ./block_level_example/uvm_tb/test/spi_test_lib_pkg.sv \
+            ./block_level_example/uvm_tb/tb/top_tb.sv \
+            ./c_stimulus_pkg/reg_api.c \
+            ./block_level_example/c_code/spi_c_poll_test.c \
+            ./block_level_example/c_code/spi_int_test.c",
+        "incdirs": "block_level_example/agents/apb_agent \
+            block_level_example/agents/spi_agent \
+            c_stimulus_pkg \
+            block_level_example/rtl/spi/rtl/verilog \
+            block_level_example/uvm_tb/uvm_register_model \
+            block_level_example/uvm_tb/env \
+            block_level_example/uvm_tb/sequences \
+            block_level_example/uvm_tb/test \
+            block_level_example/c_code",
+        "defines": "",
+    },
+    "uvm_ef_vif_config_db": {
+        "files": "./sfr_agent/sfr_agent_pkg.sv \
+            ./sfr_agent/sfr_master_bfm.sv \
+            ./sfr_agent/sfr_monitor_bfm.sv \
+            ./sfr_test_pkg/sfr_test_pkg.sv \
+            ./tb/hvl_top.sv \
+            ./tb/hdl_top.sv \
+            ./rtl/sfr_dut.sv",
+        "incdirs": "sfr_agent sfr_test_pkg",
+        "defines": "",
+    },
+    "uvm_generation_seq_persistence": {
+        "files": "./common/bus_if.sv \
+            ./common/dut.sv \
+            ./common/bus_agent_pkg.sv \
+            ./sequence_library/bus_seq_lib_pkg.sv \
+            ./tests/test_lib_pkg.sv \
+            ./common/top_tb.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_generation_seq_poly": {
+        "files": "./common/bus_if.sv \
+            ./common/dut.sv \
+            ./common/bus_agent_pkg.sv \
+            ./sequence_library/bus_seq_lib_pkg.sv \
+            ./tests/test_lib_pkg.sv \
+            ./common/top_tb.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_generation_seq_randomization": {
+        "files": "common/bus_if.sv \
+            common/dut.sv \
+            common/bus_agent_pkg.sv \
+            sequence_library/bus_seq_lib_pkg.sv \
+            tests/test_lib_pkg.sv \
+            common/top_tb.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_id_register": {
+        "files": "apb_agent/apb_agent_pkg.sv apb_agent/apb_driver_bfm.sv apb_agent/apb_monitor_bfm.sv \
+        reg_dut.sv regmodel_pkg.sv uvm_tb_pkg.sv hvl_top.sv hdl_top.sv",
+        "incdirs": "apb_agent",
+        "defines": "",
+    },
+    "uvm_interrupts_parallel_processing": {
+        "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
+            parallel_processing/dsp_chain.sv \
+            parallel_processing/dsp_con_pkg.sv \
+            parallel_processing/dsp_con_driver_bfm.sv \
+            parallel_processing/top.sv",
+        "incdirs": "utils/interrupt parallel_processing",
+        "defines": "",
+    },
+    "uvm_interrupts_prioritized": {
+        "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
+            bidirect_bus_agent_pkg.sv prioritised/top.sv",
+        "incdirs": "utils/interrupt",
+        "defines": "",
+    },
+    "uvm_interrupts_simple": {
+        "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
+            bidirect_bus_agent_pkg.sv simple/top.sv",
+        "incdirs": "utils/interrupt",
+        "defines": "",
+    },
+    "uvm_many_to_one": {
+        "files": "./b.sv \
+            ./a.sv \
+            ./c.sv \
+            ./abc_layering.sv \
+            ./env.sv \
+            ./test.sv",
+        "incdirs": ".",
+        "defines": "",
+    },
+    "uvm_messaging_example": {
+        "files": "messaging_example.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_overriding": {
+        "files": "a_agent_pkg.sv top.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_param_vif_config_db": {
+        "files": "./sfr_agent/sfr_agent_pkg.sv \
+            ./sfr_agent/sfr_master_bfm.sv \
+            ./sfr_agent/sfr_monitor_bfm.sv \
+            ./tb/tb_params_pkg.sv \
+            ./sfr_test_pkg/sfr_test_pkg.sv \
+            ./tb/hdl_top.sv \
+            ./tb/hvl_top.sv \
+            ./rtl/sfr_dut.sv",
+        "incdirs": "sfr_agent sfr_test_pkg",
+        "defines": "",
+    },
+    "uvm_priority_arbitration": {
+        "files": "top.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_priority_grab_lock": {
+        "files": "top.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_register_mem_example": {
+        "files": "./dut/timescale.v ./dut/mem_ss.sv ./dut/reg_defs.sv \
+            ./agents/ahb_agent/ahb_agent_pkg.sv \
+            ./register_model/mem_ss_reg_pkg.sv \
+            ./agents/ahb_agent/ahb_monitor_bfm.sv \
+            ./agents/ahb_agent/ahb_if.sv \
+            ./agents/ahb_agent/ahb_driver_bfm.sv \
+            ./env/mem_ss_env_pkg.sv \
+            ./sequences/mem_ss_seq_lib_pkg.sv \
+            ./test/mem_ss_test_lib_pkg.sv \
+            ./tb/hvl_top.sv \
+            ./tb/hdl_top.sv",
+        "incdirs": "dut agents/ahb_agent register_model env sequences test utils",
+        "defines": "",
+    },
+    "uvm_register_spi_bl_tb": {
+        "files": "./rtl/spi/rtl/verilog/spi_clgen.v \
+            ./rtl/spi/rtl/verilog/timescale.v \
+            ./rtl/spi/rtl/verilog/spi_defines.v \
+            ./rtl/spi/rtl/verilog/spi_shift.v \
+            ./rtl/spi/rtl/verilog/spi_top.v \
+            ./agents/apb_agent/apb_agent_pkg.sv \
+            ./agents/spi_agent/spi_agent_pkg.sv \
+            ./block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv \
+            ./agents/spi_agent/spi_monitor_bfm.sv \
+            ./agents/spi_agent/spi_driver_bfm.sv \
+            ./agents/spi_agent/spi_if.sv \
+            ./agents/apb_agent/apb_driver_bfm.sv \
+            ./agents/apb_agent/apb_if.sv \
+            ./agents/apb_agent/apb_monitor_bfm.sv \
+            ./utils/interrupt/intr_pkg.sv \
+            ./utils/interrupt/intr_bfm.sv \
+            ./utils/interrupt/intr_if.sv \
+            ./block_level_tbs/spi_tb/env/spi_env_pkg.sv \
+            ./block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv \
+            ./block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv \
+            ./block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv \
+            ./block_level_tbs/spi_tb/tb/hvl_top.sv \
+            ./block_level_tbs/spi_tb/tb/hdl_top.sv",
+        "incdirs": "rtl/spi/rtl/verilog agents/apb_agent agents/spi_agent utils utils/interrupt \
+        block_level_tbs/spi_tb/env \
+        block_level_tbs/spi_tb/sequences \
+        block_level_tbs/spi_tb/test",
+        "defines": "",
+    },
+    "uvm_slave_agent": {
+        "files": "agents/apb_slave_agent/apb_slave_agent_pkg.sv \
+            ./agents/apb_slave_agent/apb_if.sv \
+            ./agents/apb_slave_agent/apb_slave_driver_bfm.sv \
+            ./agents/apb_slave_agent/apb_slave_monitor_bfm.sv \
+            ./rtl/apb3_wlm_host.sv \
+            ./tb/env_pkg.sv \
+            ./tb/hvl_top.sv \
+            ./tb/hdl_top.sv",
+        "incdirs": "agents/apb_slave_agent tb",
+        "defines": "",
+    },
+    "uvm_slave_agent_multi_seq_item": {
+        "files": "./agents/apb_slave_agent/apb_if.sv \
+            ./agents/apb_slave_agent/apb_slave_agent_pkg.sv \
+            ./agents/apb_slave_agent/apb_slave_monitor_bfm.sv ./agents/apb_slave_agent/apb_slave_driver_bfm.sv \
+            ./rtl/apb3_wlm_host.sv \
+            ./tb/env_pkg.sv ./tb/hdl_top.sv ./tb/hvl_top.sv",
+        "incdirs": "agents/apb_slave_agent tb",
+        "defines": "",
+    },
+    "uvm_tb_build_bl_tb": {
+        "files": "./rtl/spi/rtl/verilog/spi_clgen.v \
+./rtl/spi/rtl/verilog/timescale.v \
+./rtl/spi/rtl/verilog/spi_defines.v \
+./rtl/spi/rtl/verilog/spi_shift.v \
+./rtl/spi/rtl/verilog/spi_top.v \
+    agents/apb_agent/apb_agent_pkg.sv \
+    agents/spi_agent/spi_agent_pkg.sv \
+    block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv \
+            agents/apb_agent/apb_if.sv \
+            agents/apb_agent/apb_monitor_bfm.sv \
+            agents/apb_agent/apb_driver_bfm.sv \
+            agents/spi_agent/spi_if.sv \
+            agents/spi_agent/spi_monitor_bfm.sv \
+            agents/spi_agent/spi_driver_bfm.sv \
+            utils/interrupt/intr_pkg.sv \
+            utils/interrupt/intr_if.sv \
+            utils/interrupt/intr_bfm.sv \
+            block_level_tbs/spi_tb/env/spi_env_pkg.sv \
+            block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv \
+            block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv \
+            block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv \
+            block_level_tbs/spi_tb/tb/hvl_top.sv \
+            block_level_tbs/spi_tb/tb/hdl_top.sv",
+        "incdirs": "block_level_tbs/spi_tb/env \
+            block_level_tbs/spi_tb/sequences \
+            block_level_tbs/spi_tb/register_model \
+            block_level_tbs/spi_tb/test \
+            agents/apb_agent \
+            agents/spi_agent \
+            rtl/spi/rtl/verilog \
+            utils \
+            utils/interrupt",
+        "defines": "",
+    },
+    "uvm_tb_build_ss_tb": {
+        "files": "sub_system_tbs/pss_tb/tb/hdl_top.sv \
+            sub_system_tbs/pss_tb/tb/hvl_top.sv \
+            sub_system_tbs/pss_tb/tb/binder.sv \
+            sub_system_tbs/pss_tb/tb/apb_prober.sv \
+            sub_system_tbs/pss_tb/tb/intr_if.sv \
+            rtl/spi/rtl/verilog/spi_top.v \
+            agents/apb_agent/apb_agent_pkg.sv \
+            agents/spi_agent/spi_agent_pkg.sv \
+            agents/ahb_agent/ahb_agent_pkg.sv \
+            agents/gpio_agent/gpio_agent_pkg.sv \
+            agents/modem_agent/modem_agent_pkg.sv \
+            agents/uart_agent/uart_agent_pkg.sv \
+            agents/apb_agent/apb_if.sv \
+            agents/apb_agent/apb_monitor_bfm.sv \
+            agents/apb_agent/apb_driver_bfm.sv \
+            agents/spi_agent/spi_if.sv \
+            agents/spi_agent/spi_monitor_bfm.sv \
+            agents/spi_agent/spi_driver_bfm.sv \
+            agents/gpio_agent/gpio_if.sv \
+            agents/gpio_agent/gpio_monitor_bfm.sv \
+            agents/gpio_agent/gpio_driver_bfm.sv \
+            agents/ahb_agent/ahb_if.sv \
+            agents/ahb_agent/ahb_monitor_bfm.sv \
+            agents/ahb_agent/ahb_driver_bfm.sv \
+            agents/modem_agent/modem_if.sv \
+            agents/modem_agent/modem_monitor_bfm.sv \
+            agents/modem_agent/modem_driver_bfm.sv \
+            agents/uart_agent/serial_if.sv \
+            agents/uart_agent/uart_monitor_bfm.sv \
+            agents/uart_agent/uart_driver_bfm.sv \
+            utils/interrupt/intr_pkg.sv \
+            utils/interrupt/intr_bfm.sv \
+            block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv \
+            block_level_tbs/gpio_tb/register_model/gpio_reg_pkg.sv \
+            sub_system_tbs/pss_tb/register_model/pss_reg_pkg.sv \
+            block_level_tbs/spi_tb/env/spi_env_pkg.sv \
+            block_level_tbs/gpio_tb/env/gpio_env_pkg.sv \
+            sub_system_tbs/pss_tb/env/pss_env_pkg.sv \
+            block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv \
+            block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv \
+            block_level_tbs/gpio_tb/sequences/gpio_bus_sequence_lib_pkg.sv \
+            block_level_tbs/gpio_tb/sequences/gpio_test_sequence_lib_pkg.sv \
+            sub_system_tbs/pss_tb/sequences/pss_test_seq_lib_pkg.sv \
+            sub_system_tbs/pss_tb/test/pss_test_lib_pkg.sv \
+            block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv",
+        "incdirs": "rtl/spi/rtl/verilog \
+            block_level_tbs/spi_tb/test \
+            rtl/uart/rtl \
+            agents/apb_agent \
+            agents/spi_agent \
+            agents/ahb_agent \
+            agents/gpio_agent \
+            agents/modem_agent \
+            agents/uart_agent \
+            utils \
+            utils/interrupt \
+            block_level_tbs/spi_tb/register_model \
+            block_level_tbs/gpio_tb/register_model \
+            sub_system_tbs/pss_tb/test \
+            sub_system_tbs/pss_tb/sequences \
+            block_level_tbs/gpio_tb/env \
+            block_level_tbs/gpio_tb/sequences \
+            sub_system_tbs/pss_tb/register_model \
+            block_level_tbs/spi_tb/env \
+            sub_system_tbs/pss_tb/env \
+            block_level_tbs/spi_tb/sequences \
+            block_level_tbs/gpio_tb/sequences",
+        "defines": "",
+    },
+    "uvm_test_init": {
+        "files": "agent_a_pkg.sv \
+            agent_b_pkg.sv \
+            agent_c_pkg.sv \
+            env_1_pkg.sv \
+            env_2_pkg.sv \
+            env_top_pkg.sv \
+            top_vseq_pkg.sv \
+            top.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_use_models_bidir_get_put": {
+        "files": "top_tb.sv top_hdl.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_use_models_bidir_item_done": {
+        "files": "top_tb.sv top_hdl.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_use_models_pipelined_get_put": {
+        "files": "mbus_slave/mbus_types_pkg.sv \
+        pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv \
+        mbus_slave/mbus_slave.sv \
+        pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_driver_bfm.sv \
+        pipelined_get_put/top_tb.sv pipelined_get_put/top_hdl.sv",
+        "incdirs": "pipelined_get_put/mbus_pipelined_agent",
+        "defines": "",
+    },
+    "uvm_use_models_pipelined_item_done": {
+        "files": "./mbus_slave/mbus_slave.sv \
+            ./pipelined_item_done/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv \
+            ./pipelined_item_done/top.sv",
+        "incdirs": "pipelined_item_done/mbus_pipelined_agent",
+        "defines": "",
+    },
+    "uvm_use_models_unidirectional": {
+        "files": "top_tb.sv top_hdl.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+    "uvm_vif_config_db": {
+        "files": "sfr_agent/sfr_agent_pkg.sv \
+            sfr_agent/sfr_if.sv \
+            sfr_test_pkg/sfr_test_pkg.sv \
+            tb/hdl_top.sv \
+            tb/hvl_top.sv \
+            rtl/sfr_dut.sv",
+        "incdirs": "sfr_agent sfr_test_pkg",
+        "defines": "",
+    },
+    "uvm_virt_seq_find_all": {
+        "files": "simple_ovc/simple_pkg.sv top.sv",
+        "incdirs": "simple_ovc",
+        "defines": "",
+    },
+    "uvm_wait_for_signal": {
+        "files": "bus_if.sv bidirect_bus_pkg.sv bidirect_bus_driver_bfm.sv top.sv",
+        "incdirs": "",
+        "defines": "",
+    },
+}
+
+print(tests)
+for dir in os.scandir(examples_path):
+    if dir.name == ".git":
+        continue
+    test_name = dir.name
+    test = tests[test_name]
+    test_dir = os.path.join(tests_dir, 'generated', tests_subdir)
+    test_file = os.path.join(test_dir, dir.name + ".sv")
+    files = [os.path.join(examples_path, test_name, name) for name in test["files"].split()]
+    incdirs = [os.path.join(examples_path, test_name, name) for name in test["incdirs"].split()]
+    with open(test_file, "w") as f:
+        f.write(templ.format(" ".join(files), " ".join(incdirs), test["defines"], name=dir.name))

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -576,7 +576,7 @@ tests = {
 }
 
 for dir in os.scandir(examples_path):
-    if dir.name == ".git":
+    if dir.name == ".git" or dir.name == "LICENSE":
         continue
     test_name = dir.name
     test = tests[test_name]

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -22,7 +22,7 @@ templ = """/*
 :type: simulation elaboration parsing
 :timeout: 360
 :unsynthesizable: 1
-:simargs: {2}
+:simvariants: {2}
 */
 """
 
@@ -44,39 +44,80 @@ main_path = os.path.abspath(os.getcwd())
 
 tests = {
     "apb_protocol_monitor": {
-        "files": "protocol_monitor/apb_monitor.sv",
-        "incdirs": "",
-        "simargs": "",
+        "files": ["protocol_monitor/apb_monitor.sv"],
+        "incdirs": [],
+        "simvariants": [],
     },
     "biquad_example": {
-        "files": "tb/agents/signal_agent/signal_if.sv tb/agents/apb_agent/apb_if.sv tb/agents/apb_agent/apb_agent_pkg.sv tb/agents/signal_agent/signal_agent_pkg.sv",
-        "incdirs": "tb/agents/apb_agent tb/agents/signal_agent",
-        "simargs": "UVM_TESTNAME=biquad_smoke_test",
+        "files": [
+            "tb/agents/signal_agent/signal_if.sv",
+            "tb/agents/apb_agent/apb_if.sv",
+            "tb/agents/apb_agent/apb_agent_pkg.sv",
+            "tb/agents/signal_agent/signal_agent_pkg.sv"
+        ],
+        "incdirs": [
+            "tb/agents/apb_agent",
+            "tb/agents/signal_agent"
+        ],
+        "simvariants": [
+            "UVM_TESTNAME=biquad_smoke_test",
+            "UVM_TESTNAME=biquad_test"
+        ],
     },
     "uart_example": {
-        "files": "rtl/uart/uart_16550.sv  rtl/uart/uart_register_file.sv rtl/uart/uart_rx_fifo.sv  rtl/uart/uart_rx.sv  rtl/uart/uart_tx_fifo.sv  rtl/uart/uart_tx.sv \
-            agents/apb_agent/apb_if.sv agents/apb_agent/apb_agent_pkg.sv agents/uart_agent/serial_if.sv agents/uart_agent/uart_agent_pkg.sv agents/modem_agent/modem_if.sv agents/modem_agent/modem_agent_pkg.sv \
-            uvm_tb/register_model/uart_reg_pkg.sv \
-            uvm_tb/env/uart_env_pkg.sv \
-            uvm_tb/sequences/host_if_seq_pkg.sv \
-            uvm_tb/sequences/uart_seq_pkg.sv \
-            uvm_tb/virtual_sequences/uart_vseq_pkg.sv \
-            uvm_tb/tests/uart_test_pkg.sv \
-            uvm_tb/tb/interrupt_if.sv \
-            protocol_monitor/apb_monitor.sv \
-            uvm_tb/tb/uart_tb.sv",
-        "incdirs": "agents/apb_agent agents/uart_agent \
-            uvm_tb/env \
-            uvm_tb/sequences \
-            uvm_tb/sequences \
-            uvm_tb/virtual_sequences \
-            uvm_tb/tests",
-        "simargs": "UVM_TESTNAME=uart_test",
+        "files": [
+            "rtl/uart/uart_16550.sv",
+            "rtl/uart/uart_register_file.sv",
+            "rtl/uart/uart_rx_fifo.sv",
+            "rtl/uart/uart_rx.sv",
+            "rtl/uart/uart_tx_fifo.sv",
+            "rtl/uart/uart_tx.sv",
+            "agents/apb_agent/apb_if.sv",
+            "agents/apb_agent/apb_agent_pkg.sv",
+            "agents/uart_agent/serial_if.sv",
+            "agents/uart_agent/uart_agent_pkg.sv",
+            "agents/modem_agent/modem_if.sv",
+            "agents/modem_agent/modem_agent_pkg.sv",
+            "uvm_tb/register_model/uart_reg_pkg.sv",
+            "uvm_tb/env/uart_env_pkg.sv",
+            "uvm_tb/sequences/host_if_seq_pkg.sv",
+            "uvm_tb/sequences/uart_seq_pkg.sv",
+            "uvm_tb/virtual_sequences/uart_vseq_pkg.sv",
+            "uvm_tb/tests/uart_test_pkg.sv",
+            "uvm_tb/tb/interrupt_if.sv",
+            "protocol_monitor/apb_monitor.sv",
+            "uvm_tb/tb/uart_tb.sv"
+        ],
+        "incdirs": [
+            "agents/apb_agent",
+            "agents/uart_agent",
+            "uvm_tb/env",
+            "uvm_tb/sequences",
+            "uvm_tb/sequences",
+            "uvm_tb/virtual_sequences",
+            "uvm_tb/tests"
+        ],
+        "simvariants": [
+            "UVM_TESTNAME=uart_test",
+            "UVM_TESTNAME=baud_rate_test",
+            "UVM_TESTNAME=modem_int_test",
+            "UVM_TESTNAME=word_format_int_test",
+            "UVM_TESTNAME=modem_poll_test",
+            "UVM_TESTNAME=word_format_poll_test"
+        ],
     },
     "uvm_ac_config_db": {
-        "files": "sfr_agent/sfr_agent_pkg.sv sfr_agent/sfr_master_bfm.sv sfr_agent/sfr_monitor_bfm.sv sfr_test_pkg/sfr_test_pkg.sv tb/hdl_top.sv  tb/hvl_top.sv rtl/sfr_dut.sv",
-        "incdirs": "sfr_agent sfr_test_pkg",
-        "simargs": "UVM_TESTNAME=sfr_test",
+        "files": [
+            "sfr_agent/sfr_agent_pkg.sv",
+            "sfr_agent/sfr_master_bfm.sv",
+            "sfr_agent/sfr_monitor_bfm.sv",
+            "sfr_test_pkg/sfr_test_pkg.sv",
+            "tb/hdl_top.sv",
+            "tb/hvl_top.sv",
+            "rtl/sfr_dut.sv"
+        ],
+        "incdirs": ["sfr_agent", "sfr_test_pkg"],
+        "simvariants": ["UVM_TESTNAME=sfr_test"],
     },
     "uvm_alu_config_analysis": {
         "files": "agent/alu_agent_pkg.sv \
@@ -85,399 +126,502 @@ tests = {
             alu/alu_if.sv  alu/alu_rtl.sv\
             uvm_tb/alu_tb_pkg.sv \
             tb/hdl_top.sv  tb/hvl_top.sv",
-        "incdirs": "agent uvm_tb",
-        "simargs": "UVM_TESTNAME=test_all_parallel",
+        "incdirs": ["agent uvm_tb"],
+        "simvariants": ["UVM_TESTNAME=test_all_parallel"],
     },
     "uvm_c_stimulus_bl_example": {
-        "files": "./c_stimulus_pkg/c_stimulus_pkg.sv \
-            ./c_stimulus_pkg/isr_pkg.sv \
-            ./block_level_example/rtl/spi/rtl/verilog/spi_clgen.v \
-            ./block_level_example/rtl/spi/rtl/verilog/timescale.v \
-            ./block_level_example/rtl/spi/rtl/verilog/spi_defines.v \
-            ./block_level_example/rtl/spi/rtl/verilog/spi_shift.v \
-            ./block_level_example/rtl/spi/rtl/verilog/spi_top.v \
-            ./block_level_example/agents/apb_agent/apb_agent_pkg.sv \
-            ./block_level_example/agents/spi_agent/spi_agent_pkg.sv \
-            ./block_level_example/uvm_tb/uvm_register_model/spi_reg_pkg.sv \
-            ./block_level_example/agents/apb_agent/apb_if.sv \
-            ./block_level_example/agents/spi_agent/spi_if.sv \
-            ./block_level_example/uvm_tb/tb/intr_if.sv \
-            ./block_level_example/uvm_tb/env/spi_env_pkg.sv \
-            ./block_level_example/uvm_tb/sequences/spi_bus_sequence_lib_pkg.sv \
-            ./block_level_example/uvm_tb/sequences/spi_sequence_lib_pkg.sv \
-            ./block_level_example/uvm_tb/sequences/spi_virtual_seq_lib_pkg.sv \
-            ./block_level_example/uvm_tb/test/spi_test_lib_pkg.sv \
-            ./block_level_example/uvm_tb/tb/top_tb.sv \
-            ./c_stimulus_pkg/reg_api.c \
-            ./block_level_example/c_code/spi_c_poll_test.c \
-            ./block_level_example/c_code/spi_int_test.c",
-        "incdirs": "block_level_example/agents/apb_agent \
-            block_level_example/agents/spi_agent \
-            c_stimulus_pkg \
-            block_level_example/rtl/spi/rtl/verilog \
-            block_level_example/uvm_tb/uvm_register_model \
-            block_level_example/uvm_tb/env \
-            block_level_example/uvm_tb/sequences \
-            block_level_example/uvm_tb/test \
-            block_level_example/c_code",
-        "simargs": "UVM_TESTNAME=spi_c_int_test",
+        "files": [
+            "./c_stimulus_pkg/c_stimulus_pkg.sv",
+            "./c_stimulus_pkg/isr_pkg.sv",
+            "./block_level_example/rtl/spi/rtl/verilog/spi_clgen.v",
+            "./block_level_example/rtl/spi/rtl/verilog/timescale.v",
+            "./block_level_example/rtl/spi/rtl/verilog/spi_defines.v",
+            "./block_level_example/rtl/spi/rtl/verilog/spi_shift.v",
+            "./block_level_example/rtl/spi/rtl/verilog/spi_top.v",
+            "./block_level_example/agents/apb_agent/apb_agent_pkg.sv",
+            "./block_level_example/agents/spi_agent/spi_agent_pkg.sv",
+            "./block_level_example/uvm_tb/uvm_register_model/spi_reg_pkg.sv",
+            "./block_level_example/agents/apb_agent/apb_if.sv",
+            "./block_level_example/agents/spi_agent/spi_if.sv",
+            "./block_level_example/uvm_tb/tb/intr_if.sv",
+            "./block_level_example/uvm_tb/env/spi_env_pkg.sv",
+            "./block_level_example/uvm_tb/sequences/spi_bus_sequence_lib_pkg.sv",
+            "./block_level_example/uvm_tb/sequences/spi_sequence_lib_pkg.sv",
+            "./block_level_example/uvm_tb/sequences/spi_virtual_seq_lib_pkg.sv",
+            "./block_level_example/uvm_tb/test/spi_test_lib_pkg.sv",
+            "./block_level_example/uvm_tb/tb/top_tb.sv",
+            "./c_stimulus_pkg/reg_api.c",
+            "./block_level_example/c_code/spi_c_poll_test.c",
+            "./block_level_example/c_code/spi_int_test.c",
+        ],
+        "incdirs": [
+            "block_level_example/agents/apb_agent",
+            "block_level_example/agents/spi_agent",
+            "c_stimulus_pkg",
+            "block_level_example/rtl/spi/rtl/verilog",
+            "block_level_example/uvm_tb/uvm_register_model",
+            "block_level_example/uvm_tb/env",
+            "block_level_example/uvm_tb/sequences",
+            "block_level_example/uvm_tb/test",
+            "block_level_example/c_code"
+        ],
+        "simvariants": [
+            "UVM_TESTNAME=spi_c_int_test",
+            "UVM_TESTNAME=spi_c_poll_test"
+        ],
     },
     "uvm_ef_vif_config_db": {
-        "files": "./sfr_agent/sfr_agent_pkg.sv \
-            ./sfr_agent/sfr_master_bfm.sv \
-            ./sfr_agent/sfr_monitor_bfm.sv \
-            ./sfr_test_pkg/sfr_test_pkg.sv \
-            ./tb/hvl_top.sv \
-            ./tb/hdl_top.sv \
-            ./rtl/sfr_dut.sv",
-        "incdirs": "sfr_agent sfr_test_pkg",
-        "simargs": "UVM_TESTNAME=sfr_test",
+        "files": [
+            "./sfr_agent/sfr_agent_pkg.sv",
+            "./sfr_agent/sfr_master_bfm.sv",
+            "./sfr_agent/sfr_monitor_bfm.sv",
+            "./sfr_test_pkg/sfr_test_pkg.sv",
+            "./tb/hvl_top.sv",
+            "./tb/hdl_top.sv",
+            "./rtl/sfr_dut.sv"],
+        "incdirs": ["sfr_agent", "sfr_test_pkg"],
+        "simvariants": ["UVM_TESTNAME=sfr_test"],
     },
     "uvm_generation_seq_persistence": {
-        "files": "./common/bus_if.sv \
-            ./common/dut.sv \
-            ./common/bus_agent_pkg.sv \
-            ./sequence_library/bus_seq_lib_pkg.sv \
-            ./tests/test_lib_pkg.sv \
-            ./common/top_tb.sv",
-        "incdirs": "",
-        "simargs": "UVM_TESTNAME=complete_transfer_test",
+        "files": [
+            "./common/bus_if.sv",
+            "./common/dut.sv",
+            "./common/bus_agent_pkg.sv",
+            "./sequence_library/bus_seq_lib_pkg.sv",
+            "./tests/test_lib_pkg.sv",
+            "./common/top_tb.sv"
+        ],
+        "incdirs": [],
+        "simvariants": ["UVM_TESTNAME=complete_transfer_test"],
     },
     "uvm_generation_seq_poly": {
-        "files": "./common/bus_if.sv \
-            ./common/dut.sv \
-            ./common/bus_agent_pkg.sv \
-            ./sequence_library/bus_seq_lib_pkg.sv \
-            ./tests/test_lib_pkg.sv \
-            ./common/top_tb.sv",
-        "incdirs": "",
-        "simargs": "UVM_TESTNAME=rand_transfer_test",
+        "files": [
+            "./common/bus_if.sv",
+            "./common/dut.sv",
+            "./common/bus_agent_pkg.sv",
+            "./sequence_library/bus_seq_lib_pkg.sv",
+            "./tests/test_lib_pkg.sv",
+            "./common/top_tb.sv"
+        ],
+        "incdirs": [],
+        "simvariants": ["UVM_TESTNAME=rand_transfer_test"],
     },
     "uvm_generation_seq_randomization": {
-        "files": "common/bus_if.sv \
-            common/dut.sv \
-            common/bus_agent_pkg.sv \
-            sequence_library/bus_seq_lib_pkg.sv \
-            tests/test_lib_pkg.sv \
-            common/top_tb.sv",
-        "incdirs": "",
-        "simargs": "UVM_TESTNAME=seq_rand_test",
+        "files": [
+            "common/bus_if.sv",
+            "common/dut.sv",
+            "common/bus_agent_pkg.sv",
+            "sequence_library/bus_seq_lib_pkg.sv",
+            "tests/test_lib_pkg.sv",
+            "common/top_tb.sv"
+        ],
+        "incdirs": [],
+        "simvariants": ["UVM_TESTNAME=seq_rand_test"],
     },
     "uvm_id_register": {
-        "files": "apb_agent/apb_agent_pkg.sv apb_agent/apb_driver_bfm.sv apb_agent/apb_monitor_bfm.sv \
-        reg_dut.sv regmodel_pkg.sv uvm_tb_pkg.sv hvl_top.sv hdl_top.sv",
-        "incdirs": "apb_agent",
-        "simargs": "",
+        "files": [
+            "apb_agent/apb_agent_pkg.sv",
+            "apb_agent/apb_driver_bfm.sv",
+            "apb_agent/apb_monitor_bfm.sv",
+            "reg_dut.sv",
+            "regmodel_pkg.sv",
+            "uvm_tb_pkg.sv",
+            "hvl_top.sv",
+            "hdl_top.sv",
+        ],
+        "incdirs": ["apb_agent"],
+        "simvariants": [],
     },
     "uvm_interrupts_parallel_processing": {
-        "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
-            parallel_processing/dsp_chain.sv \
-            parallel_processing/dsp_con_pkg.sv \
-            parallel_processing/dsp_con_driver_bfm.sv \
-            parallel_processing/top.sv",
-        "incdirs": "utils/interrupt parallel_processing",
-        "simargs": "",
+        "files": [
+            "utils/interrupt/interrupt_pkg.sv",
+            "utils/interrupt/interrupt_if.sv",
+            "parallel_processing/dsp_chain.sv",
+            "parallel_processing/dsp_con_pkg.sv",
+            "parallel_processing/dsp_con_driver_bfm.sv",
+            "parallel_processing/top.sv"
+        ],
+        "incdirs": [
+            "utils/interrupt",
+            "parallel_processing"
+        ],
+        "simvariants": [],
     },
     "uvm_interrupts_prioritized": {
-        "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
-            bidirect_bus_agent_pkg.sv prioritised/top.sv",
-        "incdirs": "utils/interrupt",
-        "simargs": "",
+        "files": [
+            "utils/interrupt/interrupt_pkg.sv",
+            "utils/interrupt/interrupt_if.sv",
+            "bidirect_bus_agent_pkg.sv",
+            "prioritised/top.sv",
+        ],
+        "incdirs": ["utils/interrupt"],
+        "simvariants": [],
     },
     "uvm_interrupts_simple": {
-        "files": "utils/interrupt/interrupt_pkg.sv utils/interrupt/interrupt_if.sv \
-            bidirect_bus_agent_pkg.sv simple/top.sv",
-        "incdirs": "utils/interrupt",
-        "simargs": "",
+        "files": [
+            "utils/interrupt/interrupt_pkg.sv",
+            "utils/interrupt/interrupt_if.sv",
+            "bidirect_bus_agent_pkg.sv",
+            "simple/top.sv",
+        ],
+        "incdirs": ["utils/interrupt"],
+        "simvariants": [],
     },
     "uvm_many_to_one": {
-        "files": "./b.sv \
-            ./a.sv \
-            ./c.sv \
-            ./abc_layering.sv \
-            ./env.sv \
-            ./test.sv",
-        "incdirs": ".",
-        "simargs": "UVM_TESTNAME=test",
+        "files": [
+            "./b.sv",
+            "./a.sv",
+            "./c.sv",
+            "./abc_layering.sv",
+            "./env.sv",
+            "./test.sv",
+        ],
+        "incdirs": ["."],
+        "simvariants": ["UVM_TESTNAME=test"],
     },
     "uvm_messaging_example": {
-        "files": "messaging_example.sv",
-        "incdirs": "",
-        "simargs": "UVM_TESTNAME=message_test",
+        "files": ["messaging_example.sv"],
+        "incdirs": [],
+        "simvariants": ["UVM_TESTNAME=message_test"],
     },
     "uvm_overriding": {
-        "files": "a_agent_pkg.sv top.sv",
-        "incdirs": "",
-        "simargs": "",
+        "files": ["a_agent_pkg.sv", "top.sv"],
+        "incdirs": [],
+        "simvariants": [],
     },
     "uvm_param_vif_config_db": {
-        "files": "./sfr_agent/sfr_agent_pkg.sv \
-            ./sfr_agent/sfr_master_bfm.sv \
-            ./sfr_agent/sfr_monitor_bfm.sv \
-            ./tb/tb_params_pkg.sv \
-            ./sfr_test_pkg/sfr_test_pkg.sv \
-            ./tb/hdl_top.sv \
-            ./tb/hvl_top.sv \
-            ./rtl/sfr_dut.sv",
-        "incdirs": "sfr_agent sfr_test_pkg",
-        "simargs": "UVM_TESTNAME=sfr_test",
+        "files": [
+            "./sfr_agent/sfr_agent_pkg.sv",
+            "./sfr_agent/sfr_master_bfm.sv",
+            "./sfr_agent/sfr_monitor_bfm.sv",
+            "./tb/tb_params_pkg.sv",
+            "./sfr_test_pkg/sfr_test_pkg.sv",
+            "./tb/hdl_top.sv",
+            "./tb/hvl_top.sv",
+            "./rtl/sfr_dut.sv",
+        ],
+        "incdirs": ["sfr_agent", "sfr_test_pkg"],
+        "simvariants": ["UVM_TESTNAME=sfr_test"],
     },
     "uvm_priority_arbitration": {
-        "files": "top.sv",
-        "incdirs": "",
-        "simargs": "ARB_TYPE=SEQ_ARB_FIFO",
+        "files": ["top.sv"],
+        "incdirs": [],
+        "simvariants": [
+            "ARB_TYPE=SEQ_ARB_FIFO",
+            "ARB_TYPE=SEQ_ARB_WEIGHTED",
+            "ARB_TYPE=SEQ_ARB_RANDOM",
+            "ARB_TYPE=SEQ_ARB_STRICT_FIFO",
+            "ARB_TYPE=SEQ_ARB_STRICT_RANDOM",
+            "ARB_TYPE=SEQ_ARB_USER",
+        ],
     },
     "uvm_priority_grab_lock": {
-        "files": "top.sv",
-        "incdirs": "",
-        "simargs": "ARB_TYPE=SEQ_ARB_FIFO",
+        "files": ["top.sv"],
+        "incdirs": [],
+        "simvariants": [
+            "ARB_TYPE=SEQ_ARB_FIFO",
+            "ARB_TYPE=SEQ_ARB_WEIGHTED",
+            "ARB_TYPE=SEQ_ARB_RANDOM",
+            "ARB_TYPE=SEQ_ARB_STRICT_FIFO",
+            "ARB_TYPE=SEQ_ARB_STRICT_RANDOM",
+            "ARB_TYPE=SEQ_ARB_USER",
+        ],
     },
     "uvm_register_mem_example": {
-        "files": "./dut/timescale.v ./dut/mem_ss.sv ./dut/reg_defs.sv \
-            ./agents/ahb_agent/ahb_agent_pkg.sv \
-            ./register_model/mem_ss_reg_pkg.sv \
-            ./agents/ahb_agent/ahb_monitor_bfm.sv \
-            ./agents/ahb_agent/ahb_if.sv \
-            ./agents/ahb_agent/ahb_driver_bfm.sv \
-            ./env/mem_ss_env_pkg.sv \
-            ./sequences/mem_ss_seq_lib_pkg.sv \
-            ./test/mem_ss_test_lib_pkg.sv \
-            ./tb/hvl_top.sv \
-            ./tb/hdl_top.sv",
-        "incdirs": "dut agents/ahb_agent register_model env sequences test utils",
-        "simargs": "UVM_TESTNAME=mem_ss_test",
+        "files": [
+            "./dut/timescale.v",
+            "./dut/mem_ss.sv",
+            "./dut/reg_defs.sv",
+            "./agents/ahb_agent/ahb_agent_pkg.sv",
+            "./register_model/mem_ss_reg_pkg.sv",
+            "./agents/ahb_agent/ahb_monitor_bfm.sv",
+            "./agents/ahb_agent/ahb_if.sv",
+            "./agents/ahb_agent/ahb_driver_bfm.sv",
+            "./env/mem_ss_env_pkg.sv",
+            "./sequences/mem_ss_seq_lib_pkg.sv",
+            "./test/mem_ss_test_lib_pkg.sv",
+            "./tb/hvl_top.sv",
+            "./tb/hdl_top.sv",
+        ],
+        "incdirs": [
+            "dut",
+            "agents/ahb_agent",
+            "register_model",
+            "env",
+            "sequences",
+            "test",
+            "utils",
+        ],
+        "simvariants": ["UVM_TESTNAME=mem_ss_test"],
     },
     "uvm_register_spi_bl_tb": {
-        "files": "./rtl/spi/rtl/verilog/spi_clgen.v \
-            ./rtl/spi/rtl/verilog/timescale.v \
-            ./rtl/spi/rtl/verilog/spi_defines.v \
-            ./rtl/spi/rtl/verilog/spi_shift.v \
-            ./rtl/spi/rtl/verilog/spi_top.v \
-            ./agents/apb_agent/apb_agent_pkg.sv \
-            ./agents/spi_agent/spi_agent_pkg.sv \
-            ./block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv \
-            ./agents/spi_agent/spi_monitor_bfm.sv \
-            ./agents/spi_agent/spi_driver_bfm.sv \
-            ./agents/spi_agent/spi_if.sv \
-            ./agents/apb_agent/apb_driver_bfm.sv \
-            ./agents/apb_agent/apb_if.sv \
-            ./agents/apb_agent/apb_monitor_bfm.sv \
-            ./utils/interrupt/intr_pkg.sv \
-            ./utils/interrupt/intr_bfm.sv \
-            ./utils/interrupt/intr_if.sv \
-            ./block_level_tbs/spi_tb/env/spi_env_pkg.sv \
-            ./block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv \
-            ./block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv \
-            ./block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv \
-            ./block_level_tbs/spi_tb/tb/hvl_top.sv \
-            ./block_level_tbs/spi_tb/tb/hdl_top.sv",
-        "incdirs": "rtl/spi/rtl/verilog agents/apb_agent agents/spi_agent utils utils/interrupt \
-        block_level_tbs/spi_tb/env \
-        block_level_tbs/spi_tb/sequences \
-        block_level_tbs/spi_tb/test",
-        "simargs": "UVM_TESTNAME=spi_interrupt_test",
+        "files": [
+            "./rtl/spi/rtl/verilog/spi_clgen.v",
+            "./rtl/spi/rtl/verilog/timescale.v",
+            "./rtl/spi/rtl/verilog/spi_defines.v",
+            "./rtl/spi/rtl/verilog/spi_shift.v",
+            "./rtl/spi/rtl/verilog/spi_top.v",
+            "./agents/apb_agent/apb_agent_pkg.sv",
+            "./agents/spi_agent/spi_agent_pkg.sv",
+            "./block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv",
+            "./agents/spi_agent/spi_monitor_bfm.sv",
+            "./agents/spi_agent/spi_driver_bfm.sv",
+            "./agents/spi_agent/spi_if.sv",
+            "./agents/apb_agent/apb_driver_bfm.sv",
+            "./agents/apb_agent/apb_if.sv",
+            "./agents/apb_agent/apb_monitor_bfm.sv",
+            "./utils/interrupt/intr_pkg.sv",
+            "./utils/interrupt/intr_bfm.sv",
+            "./utils/interrupt/intr_if.sv",
+            "./block_level_tbs/spi_tb/env/spi_env_pkg.sv",
+            "./block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv",
+            "./block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv",
+            "./block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv",
+            "./block_level_tbs/spi_tb/tb/hvl_top.sv",
+            "./block_level_tbs/spi_tb/tb/hdl_top.sv",
+        ],
+        "incdirs": [
+            "rtl/spi/rtl/verilog",
+            "agents/apb_agent",
+            "agents/spi_agent",
+            "utils",
+            "utils/interrupt",
+            "block_level_tbs/spi_tb/env",
+            "block_level_tbs/spi_tb/sequences",
+            "block_level_tbs/spi_tb/test",
+        ],
+        "simvariants": ["UVM_TESTNAME=spi_interrupt_test"],
     },
     "uvm_slave_agent": {
-        "files": "agents/apb_slave_agent/apb_slave_agent_pkg.sv \
-            ./agents/apb_slave_agent/apb_if.sv \
-            ./agents/apb_slave_agent/apb_slave_driver_bfm.sv \
-            ./agents/apb_slave_agent/apb_slave_monitor_bfm.sv \
-            ./rtl/apb3_wlm_host.sv \
-            ./tb/env_pkg.sv \
-            ./tb/hvl_top.sv \
-            ./tb/hdl_top.sv",
-        "incdirs": "agents/apb_slave_agent tb",
-        "simargs": "",
+        "files": [
+            "agents/apb_slave_agent/apb_slave_agent_pkg.sv",
+            "./agents/apb_slave_agent/apb_if.sv",
+            "./agents/apb_slave_agent/apb_slave_driver_bfm.sv",
+            "./agents/apb_slave_agent/apb_slave_monitor_bfm.sv",
+            "./rtl/apb3_wlm_host.sv",
+            "./tb/env_pkg.sv",
+            "./tb/hvl_top.sv",
+            "./tb/hdl_top.sv",
+        ],
+        "incdirs": ["agents/apb_slave_agent", "tb"],
+        "simvariants": [],
     },
     "uvm_slave_agent_multi_seq_item": {
-        "files": "./agents/apb_slave_agent/apb_if.sv \
-            ./agents/apb_slave_agent/apb_slave_agent_pkg.sv \
-            ./agents/apb_slave_agent/apb_slave_monitor_bfm.sv ./agents/apb_slave_agent/apb_slave_driver_bfm.sv \
-            ./rtl/apb3_wlm_host.sv \
-            ./tb/env_pkg.sv ./tb/hdl_top.sv ./tb/hvl_top.sv",
-        "incdirs": "agents/apb_slave_agent tb",
-        "simargs": "",
+        "files": [
+            "./agents/apb_slave_agent/apb_if.sv",
+            "./agents/apb_slave_agent/apb_slave_agent_pkg.sv",
+            "./agents/apb_slave_agent/apb_slave_monitor_bfm.sv",
+            "./agents/apb_slave_agent/apb_slave_driver_bfm.sv",
+            "./rtl/apb3_wlm_host.sv",
+            "./tb/env_pkg.sv",
+            "./tb/hdl_top.sv",
+            "./tb/hvl_top.sv",
+        ],
+        "incdirs": ["agents/apb_slave_agent", "tb"],
+        "simvariants": [],
     },
     "uvm_tb_build_bl_tb": {
-        "files": "./rtl/spi/rtl/verilog/spi_clgen.v \
-./rtl/spi/rtl/verilog/timescale.v \
-./rtl/spi/rtl/verilog/spi_defines.v \
-./rtl/spi/rtl/verilog/spi_shift.v \
-./rtl/spi/rtl/verilog/spi_top.v \
-    agents/apb_agent/apb_agent_pkg.sv \
-    agents/spi_agent/spi_agent_pkg.sv \
-    block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv \
-            agents/apb_agent/apb_if.sv \
-            agents/apb_agent/apb_monitor_bfm.sv \
-            agents/apb_agent/apb_driver_bfm.sv \
-            agents/spi_agent/spi_if.sv \
-            agents/spi_agent/spi_monitor_bfm.sv \
-            agents/spi_agent/spi_driver_bfm.sv \
-            utils/interrupt/intr_pkg.sv \
-            utils/interrupt/intr_if.sv \
-            utils/interrupt/intr_bfm.sv \
-            block_level_tbs/spi_tb/env/spi_env_pkg.sv \
-            block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv \
-            block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv \
-            block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv \
-            block_level_tbs/spi_tb/tb/hvl_top.sv \
-            block_level_tbs/spi_tb/tb/hdl_top.sv",
-        "incdirs": "block_level_tbs/spi_tb/env \
-            block_level_tbs/spi_tb/sequences \
-            block_level_tbs/spi_tb/register_model \
-            block_level_tbs/spi_tb/test \
-            agents/apb_agent \
-            agents/spi_agent \
-            rtl/spi/rtl/verilog \
-            utils \
-            utils/interrupt",
-        "simargs": "UVM_TESTNAME=spi_interrupt_test",
+        "files": [
+            "./rtl/spi/rtl/verilog/spi_clgen.v",
+            "./rtl/spi/rtl/verilog/timescale.v",
+            "./rtl/spi/rtl/verilog/spi_defines.v",
+            "./rtl/spi/rtl/verilog/spi_shift.v",
+            "./rtl/spi/rtl/verilog/spi_top.v",
+            "agents/apb_agent/apb_agent_pkg.sv",
+            "agents/spi_agent/spi_agent_pkg.sv",
+            "block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv",
+            "agents/apb_agent/apb_if.sv",
+            "agents/apb_agent/apb_monitor_bfm.sv",
+            "agents/apb_agent/apb_driver_bfm.sv",
+            "agents/spi_agent/spi_if.sv",
+            "agents/spi_agent/spi_monitor_bfm.sv",
+            "agents/spi_agent/spi_driver_bfm.sv",
+            "utils/interrupt/intr_pkg.sv",
+            "utils/interrupt/intr_if.sv",
+            "utils/interrupt/intr_bfm.sv",
+            "block_level_tbs/spi_tb/env/spi_env_pkg.sv",
+            "block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv",
+            "block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv",
+            "block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv",
+            "block_level_tbs/spi_tb/tb/hvl_top.sv",
+            "block_level_tbs/spi_tb/tb/hdl_top.sv",
+        ],
+        "incdirs": [
+            "block_level_tbs/spi_tb/env",
+            "block_level_tbs/spi_tb/sequences",
+            "block_level_tbs/spi_tb/register_model",
+            "block_level_tbs/spi_tb/test",
+            "agents/apb_agent",
+            "agents/spi_agent",
+            "rtl/spi/rtl/verilog",
+            "utils",
+            "utils/interrupt",
+        ],
+        "simvariants": ["UVM_TESTNAME=spi_interrupt_test"],
     },
     "uvm_tb_build_ss_tb": {
-        "files": "sub_system_tbs/pss_tb/tb/hdl_top.sv \
-            sub_system_tbs/pss_tb/tb/hvl_top.sv \
-            sub_system_tbs/pss_tb/tb/binder.sv \
-            sub_system_tbs/pss_tb/tb/apb_prober.sv \
-            sub_system_tbs/pss_tb/tb/intr_if.sv \
-            rtl/spi/rtl/verilog/spi_top.v \
-            agents/apb_agent/apb_agent_pkg.sv \
-            agents/spi_agent/spi_agent_pkg.sv \
-            agents/ahb_agent/ahb_agent_pkg.sv \
-            agents/gpio_agent/gpio_agent_pkg.sv \
-            agents/modem_agent/modem_agent_pkg.sv \
-            agents/uart_agent/uart_agent_pkg.sv \
-            agents/apb_agent/apb_if.sv \
-            agents/apb_agent/apb_monitor_bfm.sv \
-            agents/apb_agent/apb_driver_bfm.sv \
-            agents/spi_agent/spi_if.sv \
-            agents/spi_agent/spi_monitor_bfm.sv \
-            agents/spi_agent/spi_driver_bfm.sv \
-            agents/gpio_agent/gpio_if.sv \
-            agents/gpio_agent/gpio_monitor_bfm.sv \
-            agents/gpio_agent/gpio_driver_bfm.sv \
-            agents/ahb_agent/ahb_if.sv \
-            agents/ahb_agent/ahb_monitor_bfm.sv \
-            agents/ahb_agent/ahb_driver_bfm.sv \
-            agents/modem_agent/modem_if.sv \
-            agents/modem_agent/modem_monitor_bfm.sv \
-            agents/modem_agent/modem_driver_bfm.sv \
-            agents/uart_agent/serial_if.sv \
-            agents/uart_agent/uart_monitor_bfm.sv \
-            agents/uart_agent/uart_driver_bfm.sv \
-            utils/interrupt/intr_pkg.sv \
-            utils/interrupt/intr_bfm.sv \
-            block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv \
-            block_level_tbs/gpio_tb/register_model/gpio_reg_pkg.sv \
-            sub_system_tbs/pss_tb/register_model/pss_reg_pkg.sv \
-            block_level_tbs/spi_tb/env/spi_env_pkg.sv \
-            block_level_tbs/gpio_tb/env/gpio_env_pkg.sv \
-            sub_system_tbs/pss_tb/env/pss_env_pkg.sv \
-            block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv \
-            block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv \
-            block_level_tbs/gpio_tb/sequences/gpio_bus_sequence_lib_pkg.sv \
-            block_level_tbs/gpio_tb/sequences/gpio_test_sequence_lib_pkg.sv \
-            sub_system_tbs/pss_tb/sequences/pss_test_seq_lib_pkg.sv \
-            sub_system_tbs/pss_tb/test/pss_test_lib_pkg.sv \
-            block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv",
-        "incdirs": "rtl/spi/rtl/verilog \
-            block_level_tbs/spi_tb/test \
-            rtl/uart/rtl \
-            agents/apb_agent \
-            agents/spi_agent \
-            agents/ahb_agent \
-            agents/gpio_agent \
-            agents/modem_agent \
-            agents/uart_agent \
-            utils \
-            utils/interrupt \
-            block_level_tbs/spi_tb/register_model \
-            block_level_tbs/gpio_tb/register_model \
-            sub_system_tbs/pss_tb/test \
-            sub_system_tbs/pss_tb/sequences \
-            block_level_tbs/gpio_tb/env \
-            block_level_tbs/gpio_tb/sequences \
-            sub_system_tbs/pss_tb/register_model \
-            block_level_tbs/spi_tb/env \
-            sub_system_tbs/pss_tb/env \
-            block_level_tbs/spi_tb/sequences \
-            block_level_tbs/gpio_tb/sequences",
-        "simargs": "UVM_TESTNAME=pss_spi_interrupt_test",
+        "files": [
+            "sub_system_tbs/pss_tb/tb/hdl_top.sv",
+            "sub_system_tbs/pss_tb/tb/hvl_top.sv",
+            "sub_system_tbs/pss_tb/tb/binder.sv",
+            "sub_system_tbs/pss_tb/tb/apb_prober.sv",
+            "sub_system_tbs/pss_tb/tb/intr_if.sv",
+            "rtl/spi/rtl/verilog/spi_top.v",
+            "agents/apb_agent/apb_agent_pkg.sv",
+            "agents/spi_agent/spi_agent_pkg.sv",
+            "agents/ahb_agent/ahb_agent_pkg.sv",
+            "agents/gpio_agent/gpio_agent_pkg.sv",
+            "agents/modem_agent/modem_agent_pkg.sv",
+            "agents/uart_agent/uart_agent_pkg.sv",
+            "agents/apb_agent/apb_if.sv",
+            "agents/apb_agent/apb_monitor_bfm.sv",
+            "agents/apb_agent/apb_driver_bfm.sv",
+            "agents/spi_agent/spi_if.sv",
+            "agents/spi_agent/spi_monitor_bfm.sv",
+            "agents/spi_agent/spi_driver_bfm.sv",
+            "agents/gpio_agent/gpio_if.sv",
+            "agents/gpio_agent/gpio_monitor_bfm.sv",
+            "agents/gpio_agent/gpio_driver_bfm.sv",
+            "agents/ahb_agent/ahb_if.sv",
+            "agents/ahb_agent/ahb_monitor_bfm.sv",
+            "agents/ahb_agent/ahb_driver_bfm.sv",
+            "agents/modem_agent/modem_if.sv",
+            "agents/modem_agent/modem_monitor_bfm.sv",
+            "agents/modem_agent/modem_driver_bfm.sv",
+            "agents/uart_agent/serial_if.sv",
+            "agents/uart_agent/uart_monitor_bfm.sv",
+            "agents/uart_agent/uart_driver_bfm.sv",
+            "utils/interrupt/intr_pkg.sv",
+            "utils/interrupt/intr_bfm.sv",
+            "block_level_tbs/spi_tb/register_model/spi_reg_pkg.sv",
+            "block_level_tbs/gpio_tb/register_model/gpio_reg_pkg.sv",
+            "sub_system_tbs/pss_tb/register_model/pss_reg_pkg.sv",
+            "block_level_tbs/spi_tb/env/spi_env_pkg.sv",
+            "block_level_tbs/gpio_tb/env/gpio_env_pkg.sv",
+            "sub_system_tbs/pss_tb/env/pss_env_pkg.sv",
+            "block_level_tbs/spi_tb/sequences/spi_bus_sequence_lib_pkg.sv",
+            "block_level_tbs/spi_tb/sequences/spi_test_seq_lib_pkg.sv",
+            "block_level_tbs/gpio_tb/sequences/gpio_bus_sequence_lib_pkg.sv",
+            "block_level_tbs/gpio_tb/sequences/gpio_test_sequence_lib_pkg.sv",
+            "sub_system_tbs/pss_tb/sequences/pss_test_seq_lib_pkg.sv",
+            "sub_system_tbs/pss_tb/test/pss_test_lib_pkg.sv",
+            "block_level_tbs/spi_tb/test/spi_test_lib_pkg.sv",
+        ],
+        "incdirs": [
+            "rtl/spi/rtl/verilog",
+            "block_level_tbs/spi_tb/test",
+            "rtl/uart/rtl",
+            "agents/apb_agent",
+            "agents/spi_agent",
+            "agents/ahb_agent",
+            "agents/gpio_agent",
+            "agents/modem_agent",
+            "agents/uart_agent",
+            "utils",
+            "utils/interrupt",
+            "block_level_tbs/spi_tb/register_model",
+            "block_level_tbs/gpio_tb/register_model",
+            "sub_system_tbs/pss_tb/test",
+            "sub_system_tbs/pss_tb/sequences",
+            "block_level_tbs/gpio_tb/env",
+            "block_level_tbs/gpio_tb/sequences",
+            "sub_system_tbs/pss_tb/register_model",
+            "block_level_tbs/spi_tb/env",
+            "sub_system_tbs/pss_tb/env",
+            "block_level_tbs/spi_tb/sequences",
+            "block_level_tbs/gpio_tb/sequences",
+        ],
+        "simvariants": ["UVM_TESTNAME=pss_spi_interrupt_test"],
     },
     "uvm_test_init": {
-        "files": "agent_a_pkg.sv \
-            agent_b_pkg.sv \
-            agent_c_pkg.sv \
-            env_1_pkg.sv \
-            env_2_pkg.sv \
-            env_top_pkg.sv \
-            top_vseq_pkg.sv \
-            top.sv",
-        "incdirs": "",
-        "simargs": "UVM_TESTNAME=init_vseq_from_test",
+        "files": [
+            "agent_a_pkg.sv",
+            "agent_b_pkg.sv",
+            "agent_c_pkg.sv",
+            "env_1_pkg.sv",
+            "env_2_pkg.sv",
+            "env_top_pkg.sv",
+            "top_vseq_pkg.sv",
+            "top.sv",
+        ],
+        "incdirs": [],
+        "simvariants": ["UVM_TESTNAME=init_vseq_from_test"],
     },
     "uvm_use_models_bidir_get_put": {
-        "files": "top_tb.sv top_hdl.sv",
-        "incdirs": "",
-        "simargs": "",
+        "files": ["top_tb.sv", "top_hdl.sv"],
+        "incdirs": [],
+        "simvariants": [],
     },
     "uvm_use_models_bidir_item_done": {
-        "files": "top_tb.sv top_hdl.sv",
-        "incdirs": "",
-        "simargs": "",
+        "files": ["top_tb.sv", "top_hdl.sv"],
+        "incdirs": [],
+        "simvariants": [],
     },
     "uvm_use_models_pipelined_get_put": {
-        "files": "mbus_slave/mbus_types_pkg.sv \
-        pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv \
-        mbus_slave/mbus_slave.sv \
-        pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_driver_bfm.sv \
-        pipelined_get_put/top_tb.sv pipelined_get_put/top_hdl.sv",
-        "incdirs": "pipelined_get_put/mbus_pipelined_agent",
-        "simargs": "",
+        "files": [
+            "mbus_slave/mbus_types_pkg.sv",
+            "pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv",
+            "mbus_slave/mbus_slave.sv",
+            "pipelined_get_put/mbus_pipelined_agent/mbus_pipelined_driver_bfm.sv",
+            "pipelined_get_put/top_tb.sv",
+            "pipelined_get_put/top_hdl.sv",
+        ],
+        "incdirs": ["pipelined_get_put/mbus_pipelined_agent"],
+        "simvariants": [],
     },
     "uvm_use_models_pipelined_item_done": {
-        "files": "./mbus_slave/mbus_slave.sv \
-            ./pipelined_item_done/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv \
-            ./pipelined_item_done/top.sv",
-        "incdirs": "pipelined_item_done/mbus_pipelined_agent",
-        "simargs": "",
+        "files": [
+            "./mbus_slave/mbus_slave.sv",
+            "./pipelined_item_done/mbus_pipelined_agent/mbus_pipelined_agent_pkg.sv",
+            "./pipelined_item_done/top.sv",
+        ],
+        "incdirs": ["pipelined_item_done/mbus_pipelined_agent"],
+        "simvariants": [],
     },
     "uvm_use_models_unidirectional": {
-        "files": "top_tb.sv top_hdl.sv",
-        "incdirs": "",
-        "simargs": "",
+        "files": ["top_tb.sv", "top_hdl.sv"],
+        "incdirs": [],
+        "simvariants": [],
     },
     "uvm_vif_config_db": {
-        "files": "sfr_agent/sfr_agent_pkg.sv \
-            sfr_agent/sfr_if.sv \
-            sfr_test_pkg/sfr_test_pkg.sv \
-            tb/hdl_top.sv \
-            tb/hvl_top.sv \
-            rtl/sfr_dut.sv",
-        "incdirs": "sfr_agent sfr_test_pkg",
-        "simargs": "UVM_TESTNAME=sfr_test",
+        "files": [
+            "sfr_agent/sfr_agent_pkg.sv",
+            "sfr_agent/sfr_if.sv",
+            "sfr_test_pkg/sfr_test_pkg.sv",
+            "tb/hdl_top.sv",
+            "tb/hvl_top.sv",
+            "rtl/sfr_dut.sv",
+        ],
+        "incdirs": ["sfr_agent", "sfr_test_pkg"],
+        "simvariants": ["UVM_TESTNAME=sfr_test"],
     },
     "uvm_virt_seq_find_all": {
-        "files": "simple_ovc/simple_pkg.sv top.sv",
-        "incdirs": "simple_ovc",
-        "simargs": "",
+        "files": ["simple_ovc/simple_pkg.sv", "top.sv"],
+        "incdirs": ["simple_ovc"],
+        "simvariants": [],
     },
     "uvm_wait_for_signal": {
-        "files": "bus_if.sv bidirect_bus_pkg.sv bidirect_bus_driver_bfm.sv top.sv",
-        "incdirs": "",
-        "simargs": "",
+        "files": [
+            "bus_if.sv",
+            "bidirect_bus_pkg.sv",
+            "bidirect_bus_driver_bfm.sv",
+            "top.sv",
+        ],
+        "incdirs": [],
+        "simvariants": [],
     },
 }
 
-print(tests)
 for dir in os.scandir(examples_path):
     if dir.name == ".git":
         continue
     test_name = dir.name
     test = tests[test_name]
     test_dir = os.path.join(tests_dir, 'generated', tests_subdir)
+    if not os.path.isdir(test_dir):
+        os.makedirs(test_dir, exist_ok=True)
     test_file = os.path.join(test_dir, dir.name + ".sv")
-    files = [os.path.join(examples_path, test_name, name) for name in test["files"].split()]
-    incdirs = [os.path.join(examples_path, test_name, name) for name in test["incdirs"].split()]
-    print(test["simargs"])
+    files = [os.path.join(examples_path, test_name, name) for name in test["files"]]
+    incdirs = [os.path.join(examples_path, test_name, name) for name in test["incdirs"]]
     with open(test_file, "w") as f:
-        f.write(templ.format(" ".join(files), " ".join(incdirs), test["simargs"], name=dir.name))
+        f.write(templ.format(" ".join(files), " ".join(incdirs), " ".join(test["simvariants"]), name=dir.name))

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -39,7 +39,8 @@ except IndexError:
     print("Usage: ./generator <subdir>")
     sys.exit(1)
 
-examples_path = os.path.abspath(os.path.join(third_party_dir, "tests", "uvm-examples"))
+examples_path = os.path.abspath(
+    os.path.join(third_party_dir, "tests", "uvm-examples"))
 main_path = os.path.abspath(os.getcwd())
 
 tests = {
@@ -55,25 +56,16 @@ tests = {
             "tb/agents/apb_agent/apb_agent_pkg.sv",
             "tb/agents/signal_agent/signal_agent_pkg.sv"
         ],
-        "incdirs": [
-            "tb/agents/apb_agent",
-            "tb/agents/signal_agent"
-        ],
-        "simvariants": [
-            "UVM_TESTNAME=biquad_smoke_test",
-            "UVM_TESTNAME=biquad_test"
-        ],
+        "incdirs": ["tb/agents/apb_agent", "tb/agents/signal_agent"],
+        "simvariants":
+        ["UVM_TESTNAME=biquad_smoke_test", "UVM_TESTNAME=biquad_test"],
     },
     "uart_example": {
         "files": [
-            "rtl/uart/uart_16550.sv",
-            "rtl/uart/uart_register_file.sv",
-            "rtl/uart/uart_rx_fifo.sv",
-            "rtl/uart/uart_rx.sv",
-            "rtl/uart/uart_tx_fifo.sv",
-            "rtl/uart/uart_tx.sv",
-            "agents/apb_agent/apb_if.sv",
-            "agents/apb_agent/apb_agent_pkg.sv",
+            "rtl/uart/uart_16550.sv", "rtl/uart/uart_register_file.sv",
+            "rtl/uart/uart_rx_fifo.sv", "rtl/uart/uart_rx.sv",
+            "rtl/uart/uart_tx_fifo.sv", "rtl/uart/uart_tx.sv",
+            "agents/apb_agent/apb_if.sv", "agents/apb_agent/apb_agent_pkg.sv",
             "agents/uart_agent/serial_if.sv",
             "agents/uart_agent/uart_agent_pkg.sv",
             "agents/modem_agent/modem_if.sv",
@@ -83,38 +75,26 @@ tests = {
             "uvm_tb/sequences/host_if_seq_pkg.sv",
             "uvm_tb/sequences/uart_seq_pkg.sv",
             "uvm_tb/virtual_sequences/uart_vseq_pkg.sv",
-            "uvm_tb/tests/uart_test_pkg.sv",
-            "uvm_tb/tb/interrupt_if.sv",
-            "protocol_monitor/apb_monitor.sv",
-            "uvm_tb/tb/uart_tb.sv"
+            "uvm_tb/tests/uart_test_pkg.sv", "uvm_tb/tb/interrupt_if.sv",
+            "protocol_monitor/apb_monitor.sv", "uvm_tb/tb/uart_tb.sv"
         ],
         "incdirs": [
-            "agents/apb_agent",
-            "agents/uart_agent",
-            "uvm_tb/env",
-            "uvm_tb/sequences",
-            "uvm_tb/sequences",
-            "uvm_tb/virtual_sequences",
+            "agents/apb_agent", "agents/uart_agent", "uvm_tb/env",
+            "uvm_tb/sequences", "uvm_tb/sequences", "uvm_tb/virtual_sequences",
             "uvm_tb/tests"
         ],
         "simvariants": [
-            "UVM_TESTNAME=uart_test",
-            "UVM_TESTNAME=baud_rate_test",
-            "UVM_TESTNAME=modem_int_test",
-            "UVM_TESTNAME=word_format_int_test",
+            "UVM_TESTNAME=uart_test", "UVM_TESTNAME=baud_rate_test",
+            "UVM_TESTNAME=modem_int_test", "UVM_TESTNAME=word_format_int_test",
             "UVM_TESTNAME=modem_poll_test",
             "UVM_TESTNAME=word_format_poll_test"
         ],
     },
     "uvm_ac_config_db": {
         "files": [
-            "sfr_agent/sfr_agent_pkg.sv",
-            "sfr_agent/sfr_master_bfm.sv",
-            "sfr_agent/sfr_monitor_bfm.sv",
-            "sfr_test_pkg/sfr_test_pkg.sv",
-            "tb/hdl_top.sv",
-            "tb/hvl_top.sv",
-            "rtl/sfr_dut.sv"
+            "sfr_agent/sfr_agent_pkg.sv", "sfr_agent/sfr_master_bfm.sv",
+            "sfr_agent/sfr_monitor_bfm.sv", "sfr_test_pkg/sfr_test_pkg.sv",
+            "tb/hdl_top.sv", "tb/hvl_top.sv", "rtl/sfr_dut.sv"
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
@@ -156,39 +136,30 @@ tests = {
         ],
         "incdirs": [
             "block_level_example/agents/apb_agent",
-            "block_level_example/agents/spi_agent",
-            "c_stimulus_pkg",
+            "block_level_example/agents/spi_agent", "c_stimulus_pkg",
             "block_level_example/rtl/spi/rtl/verilog",
             "block_level_example/uvm_tb/uvm_register_model",
             "block_level_example/uvm_tb/env",
             "block_level_example/uvm_tb/sequences",
-            "block_level_example/uvm_tb/test",
-            "block_level_example/c_code"
+            "block_level_example/uvm_tb/test", "block_level_example/c_code"
         ],
-        "simvariants": [
-            "UVM_TESTNAME=spi_c_int_test",
-            "UVM_TESTNAME=spi_c_poll_test"
-        ],
+        "simvariants":
+        ["UVM_TESTNAME=spi_c_int_test", "UVM_TESTNAME=spi_c_poll_test"],
     },
     "uvm_ef_vif_config_db": {
         "files": [
-            "./sfr_agent/sfr_agent_pkg.sv",
-            "./sfr_agent/sfr_master_bfm.sv",
-            "./sfr_agent/sfr_monitor_bfm.sv",
-            "./sfr_test_pkg/sfr_test_pkg.sv",
-            "./tb/hvl_top.sv",
-            "./tb/hdl_top.sv",
-            "./rtl/sfr_dut.sv"],
+            "./sfr_agent/sfr_agent_pkg.sv", "./sfr_agent/sfr_master_bfm.sv",
+            "./sfr_agent/sfr_monitor_bfm.sv", "./sfr_test_pkg/sfr_test_pkg.sv",
+            "./tb/hvl_top.sv", "./tb/hdl_top.sv", "./rtl/sfr_dut.sv"
+        ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
     },
     "uvm_generation_seq_persistence": {
         "files": [
-            "./common/bus_if.sv",
-            "./common/dut.sv",
+            "./common/bus_if.sv", "./common/dut.sv",
             "./common/bus_agent_pkg.sv",
-            "./sequence_library/bus_seq_lib_pkg.sv",
-            "./tests/test_lib_pkg.sv",
+            "./sequence_library/bus_seq_lib_pkg.sv", "./tests/test_lib_pkg.sv",
             "./common/top_tb.sv"
         ],
         "incdirs": [],
@@ -196,11 +167,9 @@ tests = {
     },
     "uvm_generation_seq_poly": {
         "files": [
-            "./common/bus_if.sv",
-            "./common/dut.sv",
+            "./common/bus_if.sv", "./common/dut.sv",
             "./common/bus_agent_pkg.sv",
-            "./sequence_library/bus_seq_lib_pkg.sv",
-            "./tests/test_lib_pkg.sv",
+            "./sequence_library/bus_seq_lib_pkg.sv", "./tests/test_lib_pkg.sv",
             "./common/top_tb.sv"
         ],
         "incdirs": [],
@@ -208,11 +177,8 @@ tests = {
     },
     "uvm_generation_seq_randomization": {
         "files": [
-            "common/bus_if.sv",
-            "common/dut.sv",
-            "common/bus_agent_pkg.sv",
-            "sequence_library/bus_seq_lib_pkg.sv",
-            "tests/test_lib_pkg.sv",
+            "common/bus_if.sv", "common/dut.sv", "common/bus_agent_pkg.sv",
+            "sequence_library/bus_seq_lib_pkg.sv", "tests/test_lib_pkg.sv",
             "common/top_tb.sv"
         ],
         "incdirs": [],
@@ -241,10 +207,7 @@ tests = {
             "parallel_processing/dsp_con_driver_bfm.sv",
             "parallel_processing/top.sv"
         ],
-        "incdirs": [
-            "utils/interrupt",
-            "parallel_processing"
-        ],
+        "incdirs": ["utils/interrupt", "parallel_processing"],
         "simvariants": [],
     },
     "uvm_interrupts_prioritized": {
@@ -621,7 +584,17 @@ for dir in os.scandir(examples_path):
     if not os.path.isdir(test_dir):
         os.makedirs(test_dir, exist_ok=True)
     test_file = os.path.join(test_dir, dir.name + ".sv")
-    files = [os.path.join(examples_path, test_name, name) for name in test["files"]]
-    incdirs = [os.path.join(examples_path, test_name, name) for name in test["incdirs"]]
+    files = [
+        os.path.join(examples_path, test_name, name) for name in test["files"]
+    ]
+    incdirs = [
+        os.path.join(examples_path, test_name, name)
+        for name in test["incdirs"]
+    ]
     with open(test_file, "w") as f:
-        f.write(templ.format(" ".join(files), " ".join(incdirs), " ".join(test["simvariants"]), name=dir.name))
+        f.write(
+            templ.format(
+                " ".join(files),
+                " ".join(incdirs),
+                " ".join(test["simvariants"]),
+                name=dir.name))

--- a/tools/runner
+++ b/tools/runner
@@ -113,7 +113,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners", "unsynthesizable", "results_group", "simargs"
+    "compatible-runners", "unsynthesizable", "results_group", "simvariants"
 ]
 
 test_params = {}
@@ -160,7 +160,7 @@ try:
             test_params.setdefault('compatible-runners', "all")
             test_params.setdefault('unsynthesizable', '0')
             test_params.setdefault('results_group', "")
-            test_params.setdefault('simargs', "")
+            test_params.setdefault('simvariants', "")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(
@@ -210,7 +210,7 @@ for key in libs.keys():
         ] + test_params['incdirs']
 
 test_params['defines'] = test_params['defines'].split()
-test_params['simargs'] = test_params['simargs'].split()
+test_params['simvariants'] = test_params['simvariants'].split()
 
 # Filter test files based on what the runner claims to support.
 filtered_files = []
@@ -282,7 +282,7 @@ try:
     test_params['files'] = ' '.join(test_params['files'])
     test_params['incdirs'] = ' '.join(test_params['incdirs'])
     test_params['defines'] = ' '.join(test_params['defines'])
-    test_params['simargs'] = ' '.join(test_params['simargs'])
+    test_params['simvariants'] = ' '.join(test_params['simvariants'])
 
     with open(out, "w") as log:
         # start by writing params

--- a/tools/runner
+++ b/tools/runner
@@ -113,7 +113,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners", "unsynthesizable", "results_group"
+    "compatible-runners", "unsynthesizable", "results_group", "simargs"
 ]
 
 test_params = {}
@@ -160,6 +160,7 @@ try:
             test_params.setdefault('compatible-runners', "all")
             test_params.setdefault('unsynthesizable', '0')
             test_params.setdefault('results_group', "")
+            test_params.setdefault('simargs', "")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(
@@ -209,6 +210,7 @@ for key in libs.keys():
         ] + test_params['incdirs']
 
 test_params['defines'] = test_params['defines'].split()
+test_params['simargs'] = test_params['simargs'].split()
 
 # Filter test files based on what the runner claims to support.
 filtered_files = []
@@ -280,6 +282,7 @@ try:
     test_params['files'] = ' '.join(test_params['files'])
     test_params['incdirs'] = ' '.join(test_params['incdirs'])
     test_params['defines'] = ' '.join(test_params['defines'])
+    test_params['simargs'] = ' '.join(test_params['simargs'])
 
     with open(out, "w") as log:
         # start by writing params

--- a/tools/runners/Icarus.py
+++ b/tools/runners/Icarus.py
@@ -55,7 +55,11 @@ class Icarus(BaseRunner):
         with open(scr, 'w') as f:
             f.write('set -x\n')
             f.write('{0} "$@" || exit $?\n'.format(self.cmd[0]))
-            f.write(f'./iverilog.out\n')
+            if not params['simvariants']:
+                f.write(f'./iverilog.out\n')
+            else:
+                for variant in params['simvariants']:
+                    f.write(f'./iverilog.out {variant}\n')
         self.cmd = ['sh', 'scr.sh'] + self.cmd[1:]
 
     def get_version_cmd(self):

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -88,14 +88,12 @@ class Verilator(BaseRunner):
 
         self.cmd += params['files']
 
-        simargs = []
-        for arg in params['simargs']:
-            simargs.append('+' + arg)
-        simargs = " ".join(simargs)
-        print(simargs)
-
         with open(scr, 'w') as f:
             f.write('set -x\n')
             f.write('{0} "$@" || exit $?\n'.format(self.executable))
             if mode == 'simulation':
-                f.write(f'./{build_dir}/{build_name} {simargs}\n')
+                if not params['simvariants']:
+                    f.write(f'./{build_dir}/{build_name}\n')
+                else:
+                    for variant in params['simvariants']:
+                        f.write(f'./{build_dir}/{build_name} +{variant}\n')

--- a/tools/runners/Verilator.py
+++ b/tools/runners/Verilator.py
@@ -88,8 +88,14 @@ class Verilator(BaseRunner):
 
         self.cmd += params['files']
 
+        simargs = []
+        for arg in params['simargs']:
+            simargs.append('+' + arg)
+        simargs = " ".join(simargs)
+        print(simargs)
+
         with open(scr, 'w') as f:
             f.write('set -x\n')
             f.write('{0} "$@" || exit $?\n'.format(self.executable))
             if mode == 'simulation':
-                f.write(f'./{build_dir}/{build_name}\n')
+                f.write(f'./{build_dir}/{build_name} {simargs}\n')

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -550,7 +550,7 @@ def collect_logs(runner_name: str):
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
             "should_fail_because", "defines", "compatible-runners",
-            "unsynthesizable", "results_group", "simargs"
+            "unsynthesizable", "results_group", "simvariants"
         }
         test_log_data: Dict[str, Any] = {}
         log_content = ""

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -550,7 +550,7 @@ def collect_logs(runner_name: str):
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
             "should_fail_because", "defines", "compatible-runners",
-            "unsynthesizable", "results_group"
+            "unsynthesizable", "results_group", "simargs"
         }
         test_log_data: Dict[str, Any] = {}
         log_content = ""


### PR DESCRIPTION
This PR adds tests from [uvm-examples](https://github.com/antmicro/uvm-examples). The repository was added as a submodule and a generator script was added to create required wrappers.

It also adds `simvariants` parameter to run the test multiple times, each one with a different argument.