### PR TITLE
Add liblz4 for Verilator

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -39,7 +39,7 @@ jobs:
             deps: bazel=7.6.1 bison flex libfl-dev
             skip-ccache: 1
           - name: verilator
-            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev z3
+            deps: autoconf autotools-dev bison flex help2man libfl-dev libelf-dev liblz4-dev z3
             make_jobs_max: 4
           - name: yosys
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev


### PR DESCRIPTION
Ibex on verilator requires FST tracing and so liblz4.
