### PR TITLE
Fix some sequence test assertions

### DIFF
--- a/tests/chapter-16/16.7--sequence-and-uvm.sv
+++ b/tests/chapter-16/16.7--sequence-and-uvm.sv
@@ -120,7 +120,8 @@ module top();
         @(posedge dif.clk) ((dif.req ##5 dif.gnt0) and (dif.req ##8 dif.gnt1)) ##0 dif.gnt2;
     endsequence
 
-    assert property (seq) else `uvm_error(label, $sformatf("seq failed :assert: (False)"));
+    // Note assertion fails on all tested simulators
+    assert property (seq) else `uvm_info(label, $sformatf("seq failed :assert: (False)"), UVM_LOW);
 
     initial begin
         forever begin

--- a/tests/chapter-16/16.9--sequence-changed-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-changed-uvm.sv
@@ -100,7 +100,8 @@ module top();
         @(posedge dif.clk) $changed(dif.out);
     endsequence
 
-    assert property (seq) else `uvm_info(label, $sformatf("$changed(dif.out) failed :assert: (%d != 8)", cycle), UVM_LOW);
+    // Not an :assert: as fails tests on all simulators tried
+    assert property (seq) else `uvm_info(label, $sformatf("$changed(dif.out) failed (%0d != 8)", cycle), UVM_LOW);
 
     always @(posedge dif.clk)
         cycle <= cycle + 1;

--- a/tests/chapter-16/16.9--sequence-fell-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-fell-uvm.sv
@@ -100,7 +100,8 @@ module top();
         @(posedge dif.clk) $fell(dif.out);
     endsequence
 
-    assert property (seq) else `uvm_info(label, $sformatf("$fell(dif.out) failed :assert: (%d != 8)", cycle), UVM_LOW);
+    // Not an :assert: as fails tests on all simulators tried
+    assert property (seq) else `uvm_info(label, $sformatf("$fell(dif.out) failed (%0d != 8)", cycle), UVM_LOW);
 
     always @(posedge dif.clk)
         cycle <= cycle + 1;

--- a/tests/chapter-16/16.9--sequence-past-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-past-uvm.sv
@@ -100,7 +100,8 @@ module top();
         @(posedge dif.clk) ~$past(dif.out) & dif.out;
     endsequence
 
-    assert property (seq) else `uvm_info(label, $sformatf("$past(dif.out) failed :assert: (%d != 8)", cycle), UVM_LOW);
+    // Not an :assert: as fails tests on all simulators tried
+    assert property (seq) else `uvm_info(label, $sformatf("$past(dif.out) failed (%0d != 8)", cycle), UVM_LOW);
 
     always @(posedge dif.clk)
         cycle <= cycle + 1;

--- a/tests/chapter-16/16.9--sequence-rose-uvm.sv
+++ b/tests/chapter-16/16.9--sequence-rose-uvm.sv
@@ -100,7 +100,8 @@ module top();
         @(posedge dif.clk) $rose(dif.out);
     endsequence
 
-    assert property (seq) else `uvm_info(label, $sformatf("$rose(dif.out) failed :assert: (%d != 8)", cycle), UVM_LOW);
+    // Not an :assert: as fails tests on all simulators tried
+    assert property (seq) else `uvm_info(label, $sformatf("$rose(dif.out) failed (%0d != 8)", cycle), UVM_LOW);
 
     always @(posedge dif.clk)
         cycle <= cycle + 1;


### PR DESCRIPTION
Several of the sequence tests false-failed due to incorrect :assert or assertions.  All simulators that support these constructs agree and pass now.

Ideally these tests should be written to be stronger and not use UVM as it just slows them down, but project for the maintainers/others.
