### PR TITLE
Pin uvm-1.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
     # UTC
     time: "22:00"
   open-pull-requests-limit: 100
+  ignore:
+    - dependency-name: "third_party/tests/uvm-1.2"


### PR DESCRIPTION
`uvm-1.2` should use version 1.2 of uvm and not be updated by dependabot.