### PR TITLE
build(deps): bump cmake version to >= 3.28 for circt-verilog

### DIFF
--- a/.github/workflows/sv-tests-ci.yml
+++ b/.github/workflows/sv-tests-ci.yml
@@ -54,7 +54,8 @@ jobs:
             deps: bison clang tcl-dev flex libfl-dev pkg-config libreadline-dev cmake pkg-config
             submodules: third_party/slang
           - name: circt-verilog
-            deps: cmake clang ninja-build lld
+            deps: clang ninja-build lld
+            cmake_ver: ">=3.28"
             submodules: llvm
     env:
       RUNNERS_FILTER: ${{ matrix.tool.runners_filter }}
@@ -130,6 +131,10 @@ jobs:
         if: ${{ contains(matrix.tool.deps, 'haskell') }}
         run: |
           stack upgrade
+      - name: Setup recent CMake (if needed)
+        if: ${{ matrix.tool.cmake_ver }}
+        run: |
+          pip install --use-pep517 "cmake${{ matrix.tool.cmake_ver }}"
       - name: Checkout the tool submodule
         run: |
           # Github dropped support for unauthorized git: https://github.blog/2021-09-01-improving-git-protocol-security-github/


### PR DESCRIPTION
Circt-verilog vendors `slang`as a build dependency. Recent `slang` releases raised their `cmake_minimum_required` to `3.28`, while the CI container  (`ubuntu:jammy-20221130`) only ships `CMake 3.22.1` through apt. This makes the `circt-verilog` build fall during configuration, as example we have this [PR](https://github.com/chipsalliance/sv-tests/pull/8677) where the CI failed.

This PR installs a recent CMake via pip specifically for for the `circt-verilog` job.

This is my first contribution to this project, so feel free to point out anything I got wrong or could do differently. 
