### PR TITLE
Check for "UVM TEST PASSED" in uvm-examples tests

### DIFF
--- a/conf/lrm.conf
+++ b/conf/lrm.conf
@@ -15,6 +15,7 @@ hdlconv_std2012	Tests imported from hdlConvertor (std2012)	https://github.com/Ni
 hdlconv_std2017	Tests imported from hdlConvertor (std2017)	https://github.com/Nic30/hdlConvertor/tree/master/tests
 utd-sv	Tests imported from utd-SystemVerilog	https://github.com/SymbiFlow/utd-sv
 uvm	Tests imported from UVM	https://github.com/SymbiFlow/uvm
+uvm-1.2	Tests using UVM-1.2
 uvm-req	UVM Prerequisites
 uvm-assertions	UVM tests using assertions
 uvm-scoreboards	uvm_scoreboard examples

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -74,7 +74,7 @@ tests = {
     },
     "uart_example": {
         "uvm_tag":
-        "uvm",
+        "uvm-1.2",
         "files": [
             "rtl/uart/uart_16550.sv", "rtl/uart/uart_register_file.sv",
             "rtl/uart/uart_rx_fifo.sv", "rtl/uart/uart_rx.sv",
@@ -119,13 +119,15 @@ tests = {
     },
     "uvm_alu_config_analysis": {
         "uvm_tag": "uvm",
-        "files": "agent/alu_agent_pkg.sv \
-            agent/alu_monitor_bfm.sv \
-            agent/alu_driver_bfm.sv \
-            alu/alu_if.sv  alu/alu_rtl.sv\
-            uvm_tb/alu_tb_pkg.sv \
-            tb/hdl_top.sv  tb/hvl_top.sv",
-        "incdirs": ["agent uvm_tb"],
+        "files": [
+            "agent/alu_agent_pkg.sv",
+            "agent/alu_monitor_bfm.sv",
+            "agent/alu_driver_bfm.sv",
+            "alu/alu_if.sv", "alu/alu_rtl.sv",
+            "uvm_tb/alu_tb_pkg.sv",
+            "tb/hdl_top.sv", "tb/hvl_top.sv"
+        ],
+        "incdirs": ["agent", "uvm_tb"],
         "simvariants": ["UVM_TESTNAME=test_all_parallel"],
         "success_info": "UVM TEST PASSED"
     },

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -47,7 +47,8 @@ main_path = os.path.abspath(os.getcwd())
 tests = {
     "apb_protocol_monitor": {
         "uvm_tag": "uvm",
-        "files": ["protocol_monitor/apb_monitor.sv", "testbench/apb_monitor_tb.sv"],
+        "files":
+        ["protocol_monitor/apb_monitor.sv", "testbench/apb_monitor_tb.sv"],
         "incdirs": [],
         "simvariants": [],
         "success_info": "TEST PASSED"
@@ -67,10 +68,14 @@ tests = {
             "tb/test/biquad_test_pkg.sv",
             "tb/tb/biquad_tb.sv",
         ],
-        "incdirs": ["tb/agents/apb_agent", "tb/agents/signal_agent", "tb/env", "tb/sequences", "tb/test"],
+        "incdirs": [
+            "tb/agents/apb_agent", "tb/agents/signal_agent", "tb/env",
+            "tb/sequences", "tb/test"
+        ],
         "simvariants":
         ["UVM_TESTNAME=biquad_smoke_test", "UVM_TESTNAME=biquad_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uart_example": {
         "uvm_tag":
@@ -103,7 +108,8 @@ tests = {
             "UVM_TESTNAME=modem_poll_test",
             "UVM_TESTNAME=word_format_poll_test"
         ],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_ac_config_db": {
         "uvm_tag":
@@ -115,21 +121,21 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_alu_config_analysis": {
-        "uvm_tag": "uvm",
+        "uvm_tag":
+        "uvm",
         "files": [
-            "agent/alu_agent_pkg.sv",
-            "agent/alu_monitor_bfm.sv",
-            "agent/alu_driver_bfm.sv",
-            "alu/alu_if.sv", "alu/alu_rtl.sv",
-            "uvm_tb/alu_tb_pkg.sv",
-            "tb/hdl_top.sv", "tb/hvl_top.sv"
+            "agent/alu_agent_pkg.sv", "agent/alu_monitor_bfm.sv",
+            "agent/alu_driver_bfm.sv", "alu/alu_if.sv", "alu/alu_rtl.sv",
+            "uvm_tb/alu_tb_pkg.sv", "tb/hdl_top.sv", "tb/hvl_top.sv"
         ],
         "incdirs": ["agent", "uvm_tb"],
         "simvariants": ["UVM_TESTNAME=test_all_parallel"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_c_stimulus_bl_example": {
         "uvm_tag":
@@ -169,7 +175,8 @@ tests = {
         ],
         "simvariants":
         ["UVM_TESTNAME=spi_c_int_test", "UVM_TESTNAME=spi_c_poll_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_ef_vif_config_db": {
         "uvm_tag":
@@ -181,7 +188,8 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_generation_seq_persistence": {
         "uvm_tag":
@@ -194,7 +202,8 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=complete_transfer_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_generation_seq_poly": {
         "uvm_tag":
@@ -207,7 +216,8 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=rand_transfer_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_generation_seq_randomization": {
         "uvm_tag":
@@ -219,7 +229,8 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=seq_rand_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_id_register": {
         "uvm_tag":
@@ -236,7 +247,8 @@ tests = {
         ],
         "incdirs": ["apb_agent"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_interrupts_parallel_processing": {
         "uvm_tag":
@@ -251,7 +263,8 @@ tests = {
         ],
         "incdirs": ["utils/interrupt", "parallel_processing"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_interrupts_prioritized": {
         "uvm_tag":
@@ -264,7 +277,8 @@ tests = {
         ],
         "incdirs": ["utils/interrupt"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_interrupts_simple": {
         "uvm_tag":
@@ -277,7 +291,8 @@ tests = {
         ],
         "incdirs": ["utils/interrupt"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_many_to_one": {
         "uvm_tag":
@@ -292,7 +307,8 @@ tests = {
         ],
         "incdirs": ["."],
         "simvariants": ["UVM_TESTNAME=test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_messaging_example": {
         "uvm_tag": "uvm",
@@ -323,7 +339,8 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_priority_arbitration": {
         "uvm_tag":
@@ -338,7 +355,8 @@ tests = {
             "ARB_TYPE=SEQ_ARB_STRICT_RANDOM",
             "ARB_TYPE=SEQ_ARB_USER",
         ],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_priority_grab_lock": {
         "uvm_tag":
@@ -353,7 +371,8 @@ tests = {
             "ARB_TYPE=SEQ_ARB_STRICT_RANDOM",
             "ARB_TYPE=SEQ_ARB_USER",
         ],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_register_mem_example": {
         "uvm_tag":
@@ -383,7 +402,8 @@ tests = {
             "utils",
         ],
         "simvariants": ["UVM_TESTNAME=mem_ss_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_register_spi_bl_tb": {
         "uvm_tag":
@@ -424,7 +444,8 @@ tests = {
             "block_level_tbs/spi_tb/test",
         ],
         "simvariants": ["UVM_TESTNAME=spi_interrupt_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_slave_agent": {
         "uvm_tag":
@@ -441,8 +462,10 @@ tests = {
         ],
         "incdirs": ["agents/apb_slave_agent", "tb"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED",
-        "extra_param": ":runner_verilator_flags: --timescale 1ns/1ns\n"
+        "success_info":
+        "UVM TEST PASSED",
+        "extra_param":
+        ":runner_verilator_flags: --timescale 1ns/1ns\n"
     },
     "uvm_slave_agent_multi_seq_item": {
         "uvm_tag":
@@ -459,8 +482,10 @@ tests = {
         ],
         "incdirs": ["agents/apb_slave_agent", "tb"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED",
-        "extra_param": ":runner_verilator_flags: --timescale 1ns/1ns\n"
+        "success_info":
+        "UVM TEST PASSED",
+        "extra_param":
+        ":runner_verilator_flags: --timescale 1ns/1ns\n"
     },
     "uvm_tb_build_bl_tb": {
         "uvm_tag":
@@ -502,7 +527,8 @@ tests = {
             "utils/interrupt",
         ],
         "simvariants": ["UVM_TESTNAME=spi_interrupt_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_tb_build_ss_tb": {
         "uvm_tag":
@@ -596,7 +622,8 @@ tests = {
             "block_level_tbs/gpio_tb/sequences",
         ],
         "simvariants": ["UVM_TESTNAME=pss_spi_interrupt_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_test_init": {
         "uvm_tag":
@@ -613,7 +640,8 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=init_vseq_from_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_use_models_bidir_get_put": {
         "uvm_tag": "uvm",
@@ -642,7 +670,8 @@ tests = {
         ],
         "incdirs": ["pipelined_get_put/mbus_pipelined_agent"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_use_models_pipelined_item_done": {
         "uvm_tag":
@@ -654,7 +683,8 @@ tests = {
         ],
         "incdirs": ["pipelined_item_done/mbus_pipelined_agent"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_use_models_unidirectional": {
         "uvm_tag": "uvm",
@@ -676,7 +706,8 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
     "uvm_virt_seq_find_all": {
         "uvm_tag": "uvm-1.2",
@@ -696,7 +727,8 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info":
+        "UVM TEST PASSED"
     },
 }
 
@@ -729,5 +761,4 @@ for dir in os.scandir(examples_path):
                 name=dir.name,
                 uvm_tag=test["uvm_tag"],
                 success_info=test["success_info"],
-                extra_param=extra_param
-            ))
+                extra_param=extra_param))

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -24,7 +24,7 @@ templ = """/*
 :unsynthesizable: 1
 :simvariants: {2}
 :success_info: {success_info}
-*/
+{extra_param}*/
 """
 
 try:
@@ -439,7 +439,8 @@ tests = {
         ],
         "incdirs": ["agents/apb_slave_agent", "tb"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info": "UVM TEST PASSED",
+        "extra_param": ":runner_verilator_flags: --timescale 1ns/1ns\n"
     },
     "uvm_slave_agent_multi_seq_item": {
         "uvm_tag":
@@ -456,7 +457,8 @@ tests = {
         ],
         "incdirs": ["agents/apb_slave_agent", "tb"],
         "simvariants": [],
-        "success_info": "UVM TEST PASSED"
+        "success_info": "UVM TEST PASSED",
+        "extra_param": ":runner_verilator_flags: --timescale 1ns/1ns\n"
     },
     "uvm_tb_build_bl_tb": {
         "uvm_tag":
@@ -712,6 +714,10 @@ for dir in os.scandir(examples_path):
         os.path.join(examples_path, test_name, name)
         for name in test["incdirs"]
     ]
+    if "extra_param" in test:
+        extra_param = test["extra_param"]
+    else:
+        extra_param = ""
     with open(test_file, "w") as f:
         f.write(
             templ.format(
@@ -720,5 +726,6 @@ for dir in os.scandir(examples_path):
                 " ".join(test["simvariants"]),
                 name=dir.name,
                 uvm_tag=test["uvm_tag"],
-                success_info=test["success_info"]
+                success_info=test["success_info"],
+                extra_param=extra_param
             ))

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -23,6 +23,7 @@ templ = """/*
 :timeout: 900
 :unsynthesizable: 1
 :simvariants: {2}
+:success_info: {success_info}
 */
 """
 
@@ -46,22 +47,30 @@ main_path = os.path.abspath(os.getcwd())
 tests = {
     "apb_protocol_monitor": {
         "uvm_tag": "uvm",
-        "files": ["protocol_monitor/apb_monitor.sv"],
+        "files": ["protocol_monitor/apb_monitor.sv", "testbench/apb_monitor_tb.sv"],
         "incdirs": [],
         "simvariants": [],
+        "success_info": "TEST PASSED"
     },
     "biquad_example": {
         "uvm_tag":
         "uvm-1.2",
         "files": [
+            "rtl/biquad.sv",
             "tb/agents/signal_agent/signal_if.sv",
             "tb/agents/apb_agent/apb_if.sv",
             "tb/agents/apb_agent/apb_agent_pkg.sv",
-            "tb/agents/signal_agent/signal_agent_pkg.sv"
+            "tb/agents/signal_agent/signal_agent_pkg.sv",
+            "tb/env/biquad_env_pkg.sv",
+            "tb/registers/biquad_reg_pkg.sv",
+            "tb/sequences/biquad_vseq_pkg.sv",
+            "tb/test/biquad_test_pkg.sv",
+            "tb/tb/biquad_tb.sv",
         ],
-        "incdirs": ["tb/agents/apb_agent", "tb/agents/signal_agent"],
+        "incdirs": ["tb/agents/apb_agent", "tb/agents/signal_agent", "tb/env", "tb/sequences", "tb/test"],
         "simvariants":
         ["UVM_TESTNAME=biquad_smoke_test", "UVM_TESTNAME=biquad_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uart_example": {
         "uvm_tag":
@@ -94,6 +103,7 @@ tests = {
             "UVM_TESTNAME=modem_poll_test",
             "UVM_TESTNAME=word_format_poll_test"
         ],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_ac_config_db": {
         "uvm_tag":
@@ -105,6 +115,7 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_alu_config_analysis": {
         "uvm_tag": "uvm",
@@ -116,6 +127,7 @@ tests = {
             tb/hdl_top.sv  tb/hvl_top.sv",
         "incdirs": ["agent uvm_tb"],
         "simvariants": ["UVM_TESTNAME=test_all_parallel"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_c_stimulus_bl_example": {
         "uvm_tag":
@@ -155,6 +167,7 @@ tests = {
         ],
         "simvariants":
         ["UVM_TESTNAME=spi_c_int_test", "UVM_TESTNAME=spi_c_poll_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_ef_vif_config_db": {
         "uvm_tag":
@@ -166,6 +179,7 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_generation_seq_persistence": {
         "uvm_tag":
@@ -178,6 +192,7 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=complete_transfer_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_generation_seq_poly": {
         "uvm_tag":
@@ -190,6 +205,7 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=rand_transfer_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_generation_seq_randomization": {
         "uvm_tag":
@@ -201,6 +217,7 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=seq_rand_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_id_register": {
         "uvm_tag":
@@ -217,6 +234,7 @@ tests = {
         ],
         "incdirs": ["apb_agent"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_interrupts_parallel_processing": {
         "uvm_tag":
@@ -231,6 +249,7 @@ tests = {
         ],
         "incdirs": ["utils/interrupt", "parallel_processing"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_interrupts_prioritized": {
         "uvm_tag":
@@ -243,6 +262,7 @@ tests = {
         ],
         "incdirs": ["utils/interrupt"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_interrupts_simple": {
         "uvm_tag":
@@ -255,6 +275,7 @@ tests = {
         ],
         "incdirs": ["utils/interrupt"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_many_to_one": {
         "uvm_tag":
@@ -269,18 +290,21 @@ tests = {
         ],
         "incdirs": ["."],
         "simvariants": ["UVM_TESTNAME=test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_messaging_example": {
         "uvm_tag": "uvm",
         "files": ["messaging_example.sv"],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=message_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_overriding": {
         "uvm_tag": "uvm",
         "files": ["a_agent_pkg.sv", "top.sv"],
         "incdirs": [],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_param_vif_config_db": {
         "uvm_tag":
@@ -297,6 +321,7 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_priority_arbitration": {
         "uvm_tag":
@@ -311,6 +336,7 @@ tests = {
             "ARB_TYPE=SEQ_ARB_STRICT_RANDOM",
             "ARB_TYPE=SEQ_ARB_USER",
         ],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_priority_grab_lock": {
         "uvm_tag":
@@ -325,6 +351,7 @@ tests = {
             "ARB_TYPE=SEQ_ARB_STRICT_RANDOM",
             "ARB_TYPE=SEQ_ARB_USER",
         ],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_register_mem_example": {
         "uvm_tag":
@@ -354,6 +381,7 @@ tests = {
             "utils",
         ],
         "simvariants": ["UVM_TESTNAME=mem_ss_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_register_spi_bl_tb": {
         "uvm_tag":
@@ -394,6 +422,7 @@ tests = {
             "block_level_tbs/spi_tb/test",
         ],
         "simvariants": ["UVM_TESTNAME=spi_interrupt_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_slave_agent": {
         "uvm_tag":
@@ -410,6 +439,7 @@ tests = {
         ],
         "incdirs": ["agents/apb_slave_agent", "tb"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_slave_agent_multi_seq_item": {
         "uvm_tag":
@@ -426,6 +456,7 @@ tests = {
         ],
         "incdirs": ["agents/apb_slave_agent", "tb"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_tb_build_bl_tb": {
         "uvm_tag":
@@ -467,6 +498,7 @@ tests = {
             "utils/interrupt",
         ],
         "simvariants": ["UVM_TESTNAME=spi_interrupt_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_tb_build_ss_tb": {
         "uvm_tag":
@@ -560,6 +592,7 @@ tests = {
             "block_level_tbs/gpio_tb/sequences",
         ],
         "simvariants": ["UVM_TESTNAME=pss_spi_interrupt_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_test_init": {
         "uvm_tag":
@@ -576,18 +609,21 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": ["UVM_TESTNAME=init_vseq_from_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_use_models_bidir_get_put": {
         "uvm_tag": "uvm",
         "files": ["top_tb.sv", "top_hdl.sv"],
         "incdirs": [],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_use_models_bidir_item_done": {
         "uvm_tag": "uvm",
         "files": ["top_tb.sv", "top_hdl.sv"],
         "incdirs": [],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_use_models_pipelined_get_put": {
         "uvm_tag":
@@ -602,6 +638,7 @@ tests = {
         ],
         "incdirs": ["pipelined_get_put/mbus_pipelined_agent"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_use_models_pipelined_item_done": {
         "uvm_tag":
@@ -613,12 +650,14 @@ tests = {
         ],
         "incdirs": ["pipelined_item_done/mbus_pipelined_agent"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_use_models_unidirectional": {
         "uvm_tag": "uvm",
         "files": ["top_tb.sv", "top_hdl.sv"],
         "incdirs": [],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_vif_config_db": {
         "uvm_tag":
@@ -633,12 +672,14 @@ tests = {
         ],
         "incdirs": ["sfr_agent", "sfr_test_pkg"],
         "simvariants": ["UVM_TESTNAME=sfr_test"],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_virt_seq_find_all": {
         "uvm_tag": "uvm-1.2",
         "files": ["simple_ovc/simple_pkg.sv", "top.sv"],
         "incdirs": ["simple_ovc"],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
     "uvm_wait_for_signal": {
         "uvm_tag":
@@ -651,6 +692,7 @@ tests = {
         ],
         "incdirs": [],
         "simvariants": [],
+        "success_info": "UVM TEST PASSED"
     },
 }
 
@@ -677,4 +719,6 @@ for dir in os.scandir(examples_path):
                 " ".join(incdirs),
                 " ".join(test["simvariants"]),
                 name=dir.name,
-                uvm_tag=test["uvm_tag"]))
+                uvm_tag=test["uvm_tag"],
+                success_info=test["success_info"]
+            ))

--- a/generators/uvm-examples
+++ b/generators/uvm-examples
@@ -24,6 +24,7 @@ templ = """/*
 :unsynthesizable: 1
 :simvariants: {2}
 :success_info: {success_info}
+:fail_message: {success_info}
 {extra_param}*/
 """
 
@@ -109,7 +110,9 @@ tests = {
             "UVM_TESTNAME=word_format_poll_test"
         ],
         "success_info":
-        "UVM TEST PASSED"
+        "UVM TEST PASSED",
+        "fail_message":
+        "UVM TEST FAILED"
     },
     "uvm_ac_config_db": {
         "uvm_tag":

--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -12,9 +12,14 @@
 import re
 
 
-def parseLog(log):
+def parseLog(log, success_info):
     res = True
+    success_pattern_found = False
     for line in log.split('\n'):
+        if success_info is not None:
+            pat = re.search(success_info, line.strip())
+            if pat:
+                success_pattern_found = True
         pat = re.search(r':([a-z]+):(.*)', line.strip())
         if pat:
             if pat.group(1) == 'assert':
@@ -24,4 +29,6 @@ def parseLog(log):
                         res = False
                 except Exception:
                     res = False
+    if success_info is not None:
+        return res and success_pattern_found
     return res

--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -16,7 +16,7 @@ def parseLog(log, success_info):
     res = True
     success_pattern_found = False
     for line in log.split('\n'):
-        if success_info is not None:
+        if success_info != "":
             pat = re.search(success_info, line.strip())
             if pat:
                 success_pattern_found = True
@@ -29,6 +29,6 @@ def parseLog(log, success_info):
                         res = False
                 except Exception:
                     res = False
-    if success_info is not None:
+    if success_info != "":
         return res and success_pattern_found
     return res

--- a/tools/logparser.py
+++ b/tools/logparser.py
@@ -12,7 +12,7 @@
 import re
 
 
-def parseLog(log, success_info):
+def parseLog(log, success_info, fail_message):
     res = True
     success_pattern_found = False
     for line in log.split('\n'):
@@ -20,6 +20,10 @@ def parseLog(log, success_info):
             pat = re.search(success_info, line.strip())
             if pat:
                 success_pattern_found = True
+        if fail_message != "":
+            pat = re.search(fail_message, line.strip())
+            if pat:
+                return False
         pat = re.search(r':([a-z]+):(.*)', line.strip())
         if pat:
             if pat.group(1) == 'assert':

--- a/tools/runner
+++ b/tools/runner
@@ -114,7 +114,7 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners", "unsynthesizable", "results_group", "simvariants"
+    "compatible-runners", "unsynthesizable", "results_group", "simvariants", "success_info"
 ]
 
 test_params = {}
@@ -162,6 +162,7 @@ try:
             test_params.setdefault('unsynthesizable', '0')
             test_params.setdefault('results_group', "")
             test_params.setdefault('simvariants', "")
+            test_params.setdefault('success_info', None)
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(
@@ -273,7 +274,7 @@ try:
     test_passed = not tool_crashed and tool_should_fail == tool_failed
 
     if test_passed and test_params['mode'] == 'simulation':
-        test_passed = parseLog(output)
+        test_passed = parseLog(output, test_params['success_info'])
 
     if test_passed:
         logger.info("PASS: {}/{}".format(args.runner, args.test))

--- a/tools/runner
+++ b/tools/runner
@@ -114,7 +114,8 @@ test = os.path.abspath(os.path.join(dirs['tests'], args.test))
 supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
-    "compatible-runners", "unsynthesizable", "results_group", "simvariants", "success_info"
+    "compatible-runners", "unsynthesizable", "results_group", "simvariants",
+    "success_info"
 ]
 
 test_params = {}

--- a/tools/runner
+++ b/tools/runner
@@ -163,7 +163,7 @@ try:
             test_params.setdefault('unsynthesizable', '0')
             test_params.setdefault('results_group', "")
             test_params.setdefault('simvariants', "")
-            test_params.setdefault('success_info', None)
+            test_params.setdefault('success_info', "")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(

--- a/tools/runner
+++ b/tools/runner
@@ -276,7 +276,8 @@ try:
     test_passed = not tool_crashed and tool_should_fail == tool_failed
 
     if test_passed and test_params['mode'] == 'simulation':
-        test_passed = parseLog(output, test_params['success_info'], test_params['fail_message'])
+        test_passed = parseLog(
+            output, test_params['success_info'], test_params['fail_message'])
 
     if test_passed:
         logger.info("PASS: {}/{}".format(args.runner, args.test))

--- a/tools/runner
+++ b/tools/runner
@@ -115,7 +115,7 @@ supported_test_params = [
     "name", "tags", "description", "files", "incdirs", "top_module", "timeout",
     "type", "should_fail", "should_fail_because", "defines",
     "compatible-runners", "unsynthesizable", "results_group", "simvariants",
-    "success_info"
+    "success_info", "fail_message"
 ]
 
 test_params = {}
@@ -164,6 +164,7 @@ try:
             test_params.setdefault('results_group', "")
             test_params.setdefault('simvariants', "")
             test_params.setdefault('success_info', "")
+            test_params.setdefault('fail_message', "")
 
             if len(set(supported_test_params) - set(test_params.keys())) != 0:
                 missing = list(
@@ -275,7 +276,7 @@ try:
     test_passed = not tool_crashed and tool_should_fail == tool_failed
 
     if test_passed and test_params['mode'] == 'simulation':
-        test_passed = parseLog(output, test_params['success_info'])
+        test_passed = parseLog(output, test_params['success_info'], test_params['fail_message'])
 
     if test_passed:
         logger.info("PASS: {}/{}".format(args.runner, args.test))

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -552,7 +552,7 @@ def collect_logs(runner_name: str):
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
             "should_fail_because", "defines", "compatible-runners",
-            "unsynthesizable", "results_group", "simvariants"
+            "unsynthesizable", "results_group", "simvariants", "success_info"
         }
         test_log_data: Dict[str, Any] = {}
         log_content = ""
@@ -625,7 +625,7 @@ def collect_logs(runner_name: str):
         if tool_crashed or tool_should_fail != tool_failed:
             test_result.status = TestStatus.FAILED
         elif (test_log_data["mode"] == "simulation"
-              and not parseLog(log_content)):
+              and not parseLog(log_content, test_log_data["success_info"])):
             test_result.status = TestStatus.FAILED
         else:
             test_result.status = TestStatus.PASSED

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -626,7 +626,8 @@ def collect_logs(runner_name: str):
         if tool_crashed or tool_should_fail != tool_failed:
             test_result.status = TestStatus.FAILED
         elif (test_log_data["mode"] == "simulation"
-              and not parseLog(log_content, test_log_data["success_info"], test_log_data["fail_message"])):
+              and not parseLog(log_content, test_log_data["success_info"],
+                               test_log_data["fail_message"])):
             test_result.status = TestStatus.FAILED
         else:
             test_result.status = TestStatus.PASSED

--- a/tools/sv-report
+++ b/tools/sv-report
@@ -552,7 +552,8 @@ def collect_logs(runner_name: str):
             "runner_url", "time_elapsed", "type", "mode", "timeout",
             "user_time", "system_time", "ram_usage", "tool_success",
             "should_fail_because", "defines", "compatible-runners",
-            "unsynthesizable", "results_group", "simvariants", "success_info"
+            "unsynthesizable", "results_group", "simvariants", "success_info",
+            "fail_message"
         }
         test_log_data: Dict[str, Any] = {}
         log_content = ""
@@ -625,7 +626,7 @@ def collect_logs(runner_name: str):
         if tool_crashed or tool_should_fail != tool_failed:
             test_result.status = TestStatus.FAILED
         elif (test_log_data["mode"] == "simulation"
-              and not parseLog(log_content, test_log_data["success_info"])):
+              and not parseLog(log_content, test_log_data["success_info"], test_log_data["fail_message"])):
             test_result.status = TestStatus.FAILED
         else:
             test_result.status = TestStatus.PASSED


### PR DESCRIPTION
Till now we only checked if the tool succeeded or failed. But tests from uvm-examples can result in error but the tool returns success. Because of that we have to add parsing of logs for test passed message