### PR TITLE
tests: add basic unpacked multidimensional array compliance check

### DIFF
--- a/tests/chapter-7/unpacked_multidim_array.sv
+++ b/tests/chapter-7/unpacked_multidim_array.sv
@@ -1,0 +1,13 @@
+/*
+:name: unpacked_multidim_array
+:description: Verifies that tools correctly parse and manipulate multi-dimensional unpacked arrays.
+:tags: 7.4
+*/
+module top;
+    int grid [2][3]; // 2 rows, 3 columns unpacked array
+
+    initial begin
+        grid[0][0] = 32'hA5A5A5A5;
+        grid[1][2] = 32'h5A5A5A5A;
+    end
+endmodule

--- a/tests/chapter-7/unpacked_multidim_array.sv
+++ b/tests/chapter-7/unpacked_multidim_array.sv
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 /*
 :name: unpacked_multidim_array
 :description: Verifies that tools correctly parse and manipulate multi-dimensional unpacked arrays.


### PR DESCRIPTION
Added a minimal compliance test case to verify that open-source simulators correctly parse and assign coordinates inside an unpacked multi-dimensional array as specified in Chapter 7 (Section 7.4) of the SystemVerilog LRM. Tested locally against Verilator, Icarus, and Yosys.